### PR TITLE
leverage-core: vendor num_div_ceil macro locally

### DIFF
--- a/kai/leverage/core/sources/clmm/position_core.move
+++ b/kai/leverage/core/sources/clmm/position_core.move
@@ -2108,7 +2108,7 @@ public(package) fun get_amount_ema_usd_value_6_decimals<T>(
     let num = p * (amount as u128);
     (if (expo + dec > 6) {
             if (round_up) {
-                std::macros::num_divide_and_round_up!(num, 10_u128.pow(expo + dec - 6))
+                util::num_div_ceil!(num, 10_u128.pow(expo + dec - 6))
             } else {
                 num / 10_u128.pow(expo + dec - 6)
             }

--- a/kai/leverage/core/sources/util.move
+++ b/kai/leverage/core/sources/util.move
@@ -45,14 +45,20 @@ public fun saturating_muldiv_round_up_u128(a: u128, b: u128, c: u128): u128 {
     }
 }
 
+public(package) macro fun num_div_ceil<$T>($x: $T, $y: $T): $T {
+    let x = $x;
+    let y = $y;
+    if (x % y == 0) x / y else x / y + 1
+}
+
 /// Divide with rounding up for 128-bit values.
 public fun divide_and_round_up_u128(a: u128, b: u128): u128 {
-    std::macros::num_divide_and_round_up!(a, b)
+    num_div_ceil!(a, b)
 }
 
 /// Divide with rounding up for u256 values.
 public fun divide_and_round_up_u256(a: u256, b: u256): u256 {
-    std::macros::num_divide_and_round_up!(a, b)
+    num_div_ceil!(a, b)
 }
 
 /// Calculate absolute difference between two numbers.


### PR DESCRIPTION
`std::macros::num_divide_and_round_up!` was changed from `public` to `public(package)` upstream, so it's no longer accessible from our package.

Vendors the macro locally as `util::num_div_ceil!` and switches the call sites in `util.move` (`divide_and_round_up_u128`, `divide_and_round_up_u256`) and `clmm/position_core.move` over to it.