### PR TITLE
rate-limiter: audit-driven fixes (cross-side staleness, _at getters, constructor validation)

### DIFF
--- a/rate-limiter/sources/net_sliding_sum_limiter.move
+++ b/rate-limiter/sources/net_sliding_sum_limiter.move
@@ -78,21 +78,62 @@ public fun outflow_limiter(self: &NetSlidingSumLimiter): &SlidingSumLimiter {
     &self.outflow_limiter
 }
 
-/// Return the total sum of all inflow values currently in the sliding window.
+/// Return the cached inflow total from the last `consume_*` or
+/// `inflow_limiter.advance`.
+///
+/// **Caution:** cached, may be stale across time gaps. For an accurate
+/// current-clock read, use `inflow_total_at(clock)`.
 public fun inflow_total(self: &NetSlidingSumLimiter): u256 {
     self.inflow_limiter.total_sum()
 }
 
-/// Return the total sum of all outflow values currently in the sliding window.
+/// Compute the inflow total that would be in the sliding window at the
+/// current clock time, without mutating the limiter.
+public fun inflow_total_at(self: &NetSlidingSumLimiter, clock: &Clock): u256 {
+    self.inflow_limiter.total_sum_at(clock)
+}
+
+/// Return the cached outflow total from the last `consume_*` or
+/// `outflow_limiter.advance`.
+///
+/// **Caution:** cached, may be stale across time gaps. For an accurate
+/// current-clock read, use `outflow_total_at(clock)`.
 public fun outflow_total(self: &NetSlidingSumLimiter): u256 {
     self.outflow_limiter.total_sum()
 }
 
-/// Return the net value as (absolute_difference, is_outflow). It's inflow if inflow >= outflow, otherwise outflow.
-/// Returns (inflow - outflow, false) if inflow >= outflow, otherwise (outflow - inflow, true).
+/// Compute the outflow total that would be in the sliding window at the
+/// current clock time, without mutating the limiter.
+public fun outflow_total_at(self: &NetSlidingSumLimiter, clock: &Clock): u256 {
+    self.outflow_limiter.total_sum_at(clock)
+}
+
+/// Return the net value as (absolute_difference, is_outflow), computed
+/// from cached inflow / outflow totals.
+///
+/// **Caution:** cached, may be stale across time gaps. If the two sides
+/// were last advanced at different positions (e.g., outside the
+/// `consume_*` paths), the absolute_difference and direction may not
+/// reflect the current sliding-window state. For an accurate
+/// current-clock read, use `net_value_at(clock)`.
 public fun net_value(self: &NetSlidingSumLimiter): (u256, bool) {
     let inflow_sum = self.inflow_limiter.total_sum();
     let outflow_sum = self.outflow_limiter.total_sum();
+
+    if (inflow_sum >= outflow_sum) {
+        (inflow_sum - outflow_sum, false)
+    } else {
+        (outflow_sum - inflow_sum, true)
+    }
+}
+
+/// Compute the net value that would be in the sliding window at the
+/// current clock time, without mutating the limiter. Returns
+/// (absolute_difference, is_outflow), where is_outflow is true if outflow
+/// dominates inflow.
+public fun net_value_at(self: &NetSlidingSumLimiter, clock: &Clock): (u256, bool) {
+    let inflow_sum = self.inflow_limiter.total_sum_at(clock);
+    let outflow_sum = self.outflow_limiter.total_sum_at(clock);
 
     if (inflow_sum >= outflow_sum) {
         (inflow_sum - outflow_sum, false)

--- a/rate-limiter/sources/net_sliding_sum_limiter.move
+++ b/rate-limiter/sources/net_sliding_sum_limiter.move
@@ -164,11 +164,20 @@ fun check_net_limits(self: &NetSlidingSumLimiter) {
 /// Consume an inflow value and add it to the current time bucket, enforcing the maximum inflow limit and net limits.
 public fun consume_inflow(self: &mut NetSlidingSumLimiter, value: u64, clock: &Clock) {
     self.inflow_limiter.consume(value, clock);
+    // Advance the opposite (outflow) side to the same clock position so
+    // `check_net_limits` reads fresh `total_sum` values from both sides.
+    // Without this, a stale outflow `total_sum` (cached at its last consume
+    // time) can cause `net_value` to misreport direction and route the cap
+    // check to the wrong limit branch.
+    self.outflow_limiter.advance(clock);
     check_net_limits(self);
 }
 
 /// Consume an outflow value and add it to the current time bucket, enforcing the maximum outflow limit and net limits.
 public fun consume_outflow(self: &mut NetSlidingSumLimiter, value: u64, clock: &Clock) {
     self.outflow_limiter.consume(value, clock);
+    // See note in `consume_inflow`. Advancing the inflow side keeps both
+    // limiters at the same clock position before the net cap check.
+    self.inflow_limiter.advance(clock);
     check_net_limits(self);
 }

--- a/rate-limiter/sources/ring_aggregator.move
+++ b/rate-limiter/sources/ring_aggregator.move
@@ -81,9 +81,44 @@ public fun current_position(self: &RingAggregator): u256 {
     self.current_position
 }
 
-/// Return the total sum of all values currently in the sliding window.
+/// Return the cached total sum from the last `advance` (or `advance_and_add`).
+///
+/// **Caution:** this is a cached field, not a fresh windowed-sum
+/// computation. Buckets that should have rolled out since the last advance
+/// are still counted. For an accurate current-time read, use
+/// `total_sum_at(position)`. See module-level note on staleness footguns.
 public fun total_sum(self: &RingAggregator): u256 {
     self.total_sum
+}
+
+/// Compute the total sum that would be in the sliding window at `position`,
+/// without mutating the aggregator. Use this when you need an accurate
+/// read but cannot — or do not want to — `advance` the aggregator.
+///
+/// Aborts if `position < self.current_position` (a sliding-window
+/// aggregator does not support reading the past).
+public fun total_sum_at(self: &RingAggregator, position: u256): u256 {
+    assert!(position >= self.current_position, EInvalidPosition);
+
+    let bucket_count = self.buckets.length();
+    let bucket_width_u256 = self.bucket_width as u256;
+    let steps = (position / bucket_width_u256) - (self.current_position / bucket_width_u256);
+
+    if (steps >= bucket_count as u256) {
+        return 0
+    };
+    if (steps == 0) {
+        return self.total_sum
+    };
+
+    let start_bucket_index = self.get_current_bucket_index() + 1;
+    let mut rolled_out_sum: u256 = 0;
+    (steps as u64).do!(|i| {
+        let bucket_value = &self.buckets[((start_bucket_index + (i as u64)) % bucket_count)];
+        rolled_out_sum = rolled_out_sum + (*bucket_value as u256);
+    });
+
+    self.total_sum - rolled_out_sum
 }
 
 /// Return a reference to the internal bucket vector for inspection.

--- a/rate-limiter/sources/ring_aggregator.move
+++ b/rate-limiter/sources/ring_aggregator.move
@@ -1,22 +1,22 @@
 /// Ring buffer-based aggregator for maintaining sliding window sums over positions.
-/// 
+///
 /// Maintains a fixed number of buckets in a circular buffer. As positions advance,
 /// the aggregator automatically rotates through buckets, zeroing out old buckets
 /// and maintaining an accurate sum of values within the sliding window.
-/// 
+///
 /// Supports configurable bucket width and count, with O(1) operations for adding
 /// values and advancing positions. Validates that positions can only advance forward.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```move
 /// // Create aggregator with 10 buckets of width 1000
 /// let mut agg = ring_aggregator::new(1000, 10);
-/// 
+///
 /// // Add values at different positions
 /// agg.advance_and_add(500, 100);   // Add 100 at position 500
 /// agg.advance_and_add(1500, 200);  // Add 200 at position 1500
-/// 
+///
 /// // Check current state
 /// let total = agg.total_sum();           // Returns 300
 /// let position = agg.current_position(); // Returns 1500
@@ -26,6 +26,10 @@ module rate_limiter::ring_aggregator;
 #[error(code = 0)]
 const EInvalidPosition: vector<u8> =
     b"New position must be greater than or equal to the current position";
+#[error(code = 1)]
+const EInvalidBucketWidth: vector<u8> = b"bucket_width must be greater than zero";
+#[error(code = 2)]
+const EInvalidBucketCount: vector<u8> = b"bucket_count must be greater than zero";
 
 public struct RingAggregator has copy, drop, store {
     buckets: vector<u128>,
@@ -44,6 +48,8 @@ fun create_empty_buckets(count: u64): vector<u128> {
 
 /// Create a new RingAggregator with the specified bucket configuration.
 public fun new(bucket_width: u64, bucket_count: u64): RingAggregator {
+    assert!(bucket_width > 0, EInvalidBucketWidth);
+    assert!(bucket_count > 0, EInvalidBucketCount);
     RingAggregator {
         buckets: create_empty_buckets(bucket_count),
         bucket_width,
@@ -58,6 +64,8 @@ public fun new_with_initial_position(
     bucket_count: u64,
     initial_position: u256,
 ): RingAggregator {
+    assert!(bucket_width > 0, EInvalidBucketWidth);
+    assert!(bucket_count > 0, EInvalidBucketCount);
     RingAggregator {
         buckets: create_empty_buckets(bucket_count),
         bucket_width,

--- a/rate-limiter/sources/ring_aggregator.move
+++ b/rate-limiter/sources/ring_aggregator.move
@@ -102,12 +102,21 @@ fun get_current_bucket_index(self: &RingAggregator): u64 {
     get_bucket_index(self, self.current_position)
 }
 
-/// Advance the aggregator to the specified position and add a value to the corresponding bucket.
-public fun advance_and_add(self: &mut RingAggregator, position: u256, value: u64) {
+/// Advance the aggregator to the specified position, zeroing any buckets that
+/// fall outside the sliding window. Does not add a value.
+///
+/// Useful for refreshing `total_sum` (and the underlying bucket vector) without
+/// recording new activity — for example, to keep two parallel aggregators on
+/// the same `current_position` so that a downstream comparison sees fresh
+/// totals on both sides.
+///
+/// Cap-safe: bucket roll-out can only decrease `total_sum` (or leave it
+/// unchanged when `position` is within the current bucket), so callers can
+/// invoke `advance` without a cap-exceedance check.
+public fun advance(self: &mut RingAggregator, position: u256) {
     assert!(position >= self.current_position, EInvalidPosition);
 
     let bucket_count = self.buckets.length();
-
     let bucket_width_u256 = self.bucket_width as u256;
     let steps = (position / bucket_width_u256) - (self.current_position / bucket_width_u256);
     if (steps >= bucket_count as u256) {
@@ -124,10 +133,16 @@ public fun advance_and_add(self: &mut RingAggregator, position: u256, value: u64
         });
     };
 
+    self.current_position = position;
+}
+
+/// Advance the aggregator to the specified position and add a value to the corresponding bucket.
+public fun advance_and_add(self: &mut RingAggregator, position: u256, value: u64) {
+    self.advance(position);
+
     let bucket_index = self.get_bucket_index(position);
     let bucket_value = &mut self.buckets[bucket_index];
     *bucket_value = *bucket_value + (value as u128);
 
     self.total_sum = self.total_sum + (value as u256);
-    self.current_position = position;
 }

--- a/rate-limiter/sources/sliding_sum_limiter.move
+++ b/rate-limiter/sources/sliding_sum_limiter.move
@@ -72,6 +72,16 @@ public fun set_max_sum_limit(self: &mut SlidingSumLimiter, max_sum_limit: Option
     self.max_sum_limit = max_sum_limit;
 }
 
+/// Advance the underlying ring aggregator to the current clock time without
+/// recording a new value. Use this to refresh `total_sum()` for accurate
+/// reads or to keep parallel limiters synchronized in time.
+///
+/// Cap-safe: the underlying advance can only decrease `total_sum` (bucket
+/// roll-out), so this call cannot trigger `EMaxSumLimitExceeded`.
+public fun advance(self: &mut SlidingSumLimiter, clock: &Clock) {
+    self.ring_aggregator.advance(clock.timestamp_ms() as u256);
+}
+
 /// Consume a value and add it to the current time bucket, enforcing the maximum sum limit.
 public fun consume(self: &mut SlidingSumLimiter, value: u64, clock: &Clock) {
     self.ring_aggregator.advance_and_add(clock.timestamp_ms() as u256, value);

--- a/rate-limiter/sources/sliding_sum_limiter.move
+++ b/rate-limiter/sources/sliding_sum_limiter.move
@@ -57,9 +57,20 @@ public fun ring_aggregator(self: &SlidingSumLimiter): &RingAggregator {
     &self.ring_aggregator
 }
 
-/// Return the total sum of all values currently in the sliding window.
+/// Return the cached total sum from the underlying ring aggregator.
+///
+/// **Caution:** this is a cached value from the last `consume` or `advance`
+/// call. Buckets that should have rolled out since then are still counted.
+/// For an accurate current-clock read, use `total_sum_at(clock)`.
 public fun total_sum(self: &SlidingSumLimiter): u256 {
     self.ring_aggregator.total_sum()
+}
+
+/// Compute the total sum that would be in the sliding window at the
+/// current clock time, without mutating the limiter. Read-only and
+/// always fresh.
+public fun total_sum_at(self: &SlidingSumLimiter, clock: &Clock): u256 {
+    self.ring_aggregator.total_sum_at(clock.timestamp_ms() as u256)
 }
 
 /// Return the current maximum sum limit.

--- a/rate-limiter/tests/net_sliding_sum_limiter_tests.move
+++ b/rate-limiter/tests/net_sliding_sum_limiter_tests.move
@@ -541,3 +541,63 @@ fun consume_outflow_aborts_when_stale_inflow_would_otherwise_bypass_net_outflow_
 
     destroy(clock);
 }
+
+// Verifies the read-only `*_at` getters report fresh windowed values without
+// requiring a consume/advance, while the cached getters retain their
+// last-advance snapshots until the next consume.
+#[test]
+fun at_getters_report_fresh_values_while_cached_getters_remain_stale() {
+    let mut ctx = tx_context::dummy();
+    let mut clock = clock::create_for_testing(&mut ctx);
+
+    clock.set_for_testing(10_000_000);
+
+    let mut net_limiter = net_sliding_sum_limiter::new(
+        5 * 60 * 1000,
+        12,
+        option::none(),
+        option::none(),
+        option::none(),
+        option::none(),
+        &clock,
+    );
+
+    // t=0: inflow lands in the window.
+    net_limiter.consume_inflow(1500, &clock);
+
+    // Same clock — cached and _at agree.
+    assert!(net_limiter.inflow_total() == 1500);
+    assert!(net_limiter.inflow_total_at(&clock) == 1500);
+    assert!(net_limiter.outflow_total() == 0);
+    assert!(net_limiter.outflow_total_at(&clock) == 0);
+    let (net, is_outflow) = net_limiter.net_value();
+    assert!(net == 1500);
+    assert!(is_outflow == false);
+    let (net_at, is_outflow_at) = net_limiter.net_value_at(&clock);
+    assert!(net_at == 1500);
+    assert!(is_outflow_at == false);
+
+    // t=65min: full window has rolled. No consume happens — cached values
+    // remain frozen at their last-advance state.
+    clock.set_for_testing(10_000_000 + 65 * 60 * 1000);
+
+    assert!(net_limiter.inflow_total() == 1500);          // cached, stale
+    assert!(net_limiter.outflow_total() == 0);            // cached
+    let (net_cached, is_outflow_cached) = net_limiter.net_value();
+    assert!(net_cached == 1500);                          // cached, stale
+    assert!(is_outflow_cached == false);
+
+    // _at variants reflect the actual rolled-out window.
+    assert!(net_limiter.inflow_total_at(&clock) == 0);    // fresh
+    assert!(net_limiter.outflow_total_at(&clock) == 0);   // fresh
+    let (net_at2, is_outflow_at2) = net_limiter.net_value_at(&clock);
+    assert!(net_at2 == 0);
+    assert!(is_outflow_at2 == false);
+
+    // Read-only invariant: the _at calls did not mutate the cached state.
+    assert!(net_limiter.inflow_total() == 1500);
+    let (net_cached2, _) = net_limiter.net_value();
+    assert!(net_cached2 == 1500);
+
+    destroy(clock);
+}

--- a/rate-limiter/tests/net_sliding_sum_limiter_tests.move
+++ b/rate-limiter/tests/net_sliding_sum_limiter_tests.move
@@ -4,7 +4,7 @@ module rate_limiter::net_sliding_sum_limiter_tests;
 use rate_limiter::net_sliding_sum_limiter;
 use rate_limiter::sliding_sum_limiter;
 use sui::clock;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun consume_inflow_outflow_is_correct() {

--- a/rate-limiter/tests/net_sliding_sum_limiter_tests.move
+++ b/rate-limiter/tests/net_sliding_sum_limiter_tests.move
@@ -493,3 +493,51 @@ fun net_limit_coverage_abort_outflow_scenario() {
 
     destroy(clock);
 }
+
+// Regression test for the cross-side staleness bug in `check_net_limits`.
+//
+// `consume_inflow` and `consume_outflow` each advance only their own side's
+// `RingAggregator`. `check_net_limits` then reads `total_sum()` from BOTH
+// sides — a cached field that is only refreshed inside `advance_and_add`.
+// If a `consume_*` call happens after a long enough quiet period for the
+// opposite side's buckets to have rolled out of the window, the cap-check
+// runs against a stale total and can pick the wrong limit branch, allowing
+// the actual net to exceed `max_net_outflow_limit` (or `max_net_inflow_limit`).
+#[test, expected_failure(abort_code = net_sliding_sum_limiter::ENetLimitExceeded)]
+fun consume_outflow_aborts_when_stale_inflow_would_otherwise_bypass_net_outflow_cap() {
+    let mut ctx = tx_context::dummy();
+    let mut clock = clock::create_for_testing(&mut ctx);
+
+    clock.set_for_testing(10_000_000);
+
+    // 5-minute buckets, 12 buckets = 1-hour window.
+    // No per-direction caps; only max_net_outflow_limit = 500.
+    let mut net_limiter = net_sliding_sum_limiter::new(
+        5 * 60 * 1000,
+        12,
+        option::none(),
+        option::none(),
+        option::none(),
+        option::some(500),
+        &clock,
+    );
+
+    // t=0: large inflow lands in bucket 0.
+    net_limiter.consume_inflow(1500, &clock);
+
+    // t = 65 min: the full 1-hour window has rolled. The bucket holding
+    // the 1500 should have been zeroed ~5 minutes after t=0, but the
+    // inflow side has not been advanced since — its cached `total_sum`
+    // is still 1500.
+    clock.set_for_testing(10_000_000 + 65 * 60 * 1000);
+
+    // Should abort with ENetLimitExceeded: the actual within-window net is
+    // 800 outflow, which exceeds the 500 max_net_outflow_limit.
+    //
+    // BUG: stale inflow.total_sum() = 1500 makes net_value() return
+    // (700, false) ("inflow-dominant"), so check_net_limits consults
+    // max_net_inflow_limit (= None) and the 800 outflow passes.
+    net_limiter.consume_outflow(800, &clock);
+
+    destroy(clock);
+}

--- a/rate-limiter/tests/ring_aggregator_tests.move
+++ b/rate-limiter/tests/ring_aggregator_tests.move
@@ -191,3 +191,23 @@ fun total_sum_at_aborts_on_backward_position() {
     // sliding-window aggregator and should abort.
     let _ = agg.total_sum_at(40);
 }
+
+#[test, expected_failure(abort_code = ring_aggregator::EInvalidBucketWidth)]
+fun new_aborts_on_zero_bucket_width() {
+    let _ = ring_aggregator::new(0, 7);
+}
+
+#[test, expected_failure(abort_code = ring_aggregator::EInvalidBucketCount)]
+fun new_aborts_on_zero_bucket_count() {
+    let _ = ring_aggregator::new(10, 0);
+}
+
+#[test, expected_failure(abort_code = ring_aggregator::EInvalidBucketWidth)]
+fun new_with_initial_position_aborts_on_zero_bucket_width() {
+    let _ = ring_aggregator::new_with_initial_position(0, 7, 100);
+}
+
+#[test, expected_failure(abort_code = ring_aggregator::EInvalidBucketCount)]
+fun new_with_initial_position_aborts_on_zero_bucket_count() {
+    let _ = ring_aggregator::new_with_initial_position(10, 0, 100);
+}

--- a/rate-limiter/tests/ring_aggregator_tests.move
+++ b/rate-limiter/tests/ring_aggregator_tests.move
@@ -127,3 +127,67 @@ fun advance_and_add_aborts_on_invalid_position() {
 
     agg.advance_and_add(10, 6);
 }
+
+#[test]
+fun total_sum_at_returns_cached_when_position_unchanged() {
+    let mut agg = ring_aggregator::new(10, 7);
+    agg.advance_and_add(0, 1);
+    agg.advance_and_add(10, 2);
+    agg.advance_and_add(20, 3);
+
+    // Same position as current — no buckets have rolled out.
+    assert!(agg.total_sum_at(20) == 6);
+
+    // Read-only invariant: cached state unchanged.
+    assert!(agg.total_sum() == 6);
+    assert!(agg.current_position() == 20);
+}
+
+#[test]
+fun total_sum_at_subtracts_rolled_out_buckets() {
+    let mut agg = ring_aggregator::new(10, 7);
+    // Fill all 7 buckets with 1, 2, ..., 7.
+    agg.advance_and_add(0, 1);
+    agg.advance_and_add(10, 2);
+    agg.advance_and_add(20, 3);
+    agg.advance_and_add(30, 4);
+    agg.advance_and_add(40, 5);
+    agg.advance_and_add(50, 6);
+    agg.advance_and_add(60, 7);
+    assert!(agg.total_sum() == 28);
+
+    // Same position — nothing rolled out.
+    assert!(agg.total_sum_at(60) == 28);
+
+    // 1 step forward (position 70..79 = bucket index 0): bucket 0 (value 1)
+    // would roll out.
+    assert!(agg.total_sum_at(70) == 27);
+    assert!(agg.total_sum_at(75) == 27);
+
+    // 2 steps forward (position 80..89): buckets at indices 0, 1
+    // (values 1, 2) would roll out.
+    assert!(agg.total_sum_at(80) == 25);
+
+    // 6 steps forward (position 120): buckets 0..5 (values 1..6) roll out;
+    // only bucket 6 (value 7) remains.
+    assert!(agg.total_sum_at(120) == 7);
+
+    // 7 steps forward (position 130): full window has rolled, all out.
+    assert!(agg.total_sum_at(130) == 0);
+
+    // Far in the future: still 0.
+    assert!(agg.total_sum_at(1_000_000) == 0);
+
+    // After all those reads, cached state is unchanged.
+    assert!(agg.total_sum() == 28);
+    assert!(agg.current_position() == 60);
+}
+
+#[test, expected_failure(abort_code = ring_aggregator::EInvalidPosition)]
+fun total_sum_at_aborts_on_backward_position() {
+    let mut agg = ring_aggregator::new(10, 7);
+    agg.advance_and_add(50, 5);
+    // Reading at a position before current_position is not meaningful for a
+    // sliding-window aggregator and should abort.
+    let _ = agg.total_sum_at(40);
+}

--- a/rate-limiter/tests/sliding_sum_limiter_tests.move
+++ b/rate-limiter/tests/sliding_sum_limiter_tests.move
@@ -87,3 +87,30 @@ fun consume_aborts_on_max_sum_limit_exceeded() {
 
     destroy(clock);
 }
+
+#[test]
+fun total_sum_at_returns_fresh_value_after_window_roll() {
+    let mut ctx = tx_context::dummy();
+    let mut clock = clock::create_for_testing(&mut ctx);
+
+    clock.set_for_testing(10_000_000);
+
+    // 5-minute buckets, 12 buckets = 1-hour window. No cap.
+    let mut limiter = sliding_sum_limiter::new(5 * 60 * 1000, 12, option::none(), &clock);
+
+    limiter.consume(1000, &clock);
+    assert!(limiter.total_sum() == 1000);
+    // Read at the same clock time matches the cached value.
+    assert!(limiter.total_sum_at(&clock) == 1000);
+
+    // Advance the clock past the full window, but do NOT consume. The cached
+    // total_sum is stale; total_sum_at must report the fresh value.
+    clock.set_for_testing(10_000_000 + 65 * 60 * 1000);
+    assert!(limiter.total_sum() == 1000);            // cached, stale
+    assert!(limiter.total_sum_at(&clock) == 0);      // fresh
+
+    // Read-only invariant: cached value unchanged after total_sum_at calls.
+    assert!(limiter.total_sum() == 1000);
+
+    destroy(clock);
+}

--- a/rate-limiter/tests/sliding_sum_limiter_tests.move
+++ b/rate-limiter/tests/sliding_sum_limiter_tests.move
@@ -3,7 +3,7 @@ module rate_limiter::sliding_sum_limiter_tests;
 
 use rate_limiter::sliding_sum_limiter;
 use sui::clock;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 fun empty_buckets(count: u64): vector<u128> {
     let mut buckets = vector::empty();


### PR DESCRIPTION
## Summary

Three audit-driven fixes to `rate-limiter`.

### [High] Cross-side staleness lets net cap be bypassed

`check_net_limits` reads `total_sum` from both inflow and outflow ring aggregators without first advancing them to the current clock. `consume_inflow` advances only inflow; `consume_outflow` advances only outflow. Across a time gap, the opposite side's cached `total_sum` reflects buckets that should have rolled out, causing `net_value` to pick the wrong limit branch.

**Reproduction**: with `max_net_outflow_limit = 500`, call `consume_inflow(1500)` at t=0, then `consume_outflow(800)` at t=65min (window has rolled). Stale inflow makes `net_value` indicate inflow-dominant; `max_net_inflow_limit` (large) is consulted instead of `max_net_outflow_limit` (small) and the 800 net outflow passes.

**Fix**: factored a no-add `RingAggregator::advance(position)` out of `advance_and_add`. `consume_inflow`/`consume_outflow` now advance the opposite limiter before `check_net_limits`. Both ring aggregators sit at the same clock position when the cap check runs.

### Read-only `_at(clock)` getters

Same root cause from the read-only-consumer angle: cached getters can be stale across time gaps. Added `_at(clock)` variants on every layer that compute the windowed sum without mutating. Cached getters now have doc-comment warnings pointing at the `_at` variants.

### [Low] Constructor input validation

`ring_aggregator::new` and `new_with_initial_position` didn't validate `bucket_width > 0` or `bucket_count > 0`. Misconfigured limiters constructed cleanly but aborted on first use via division-by-zero. Both constructors now assert these invariants; wrappers funnel through these so no further checks are needed.

## Test plan

- [x] `sui move test --path rate-limiter` — 28 tests pass
- [x] Cross-side-staleness regression test
- [x] 5 `_at`-getter coverage tests
- [x] 4 bucket-validation tests (zero width and zero count, both constructors)