### PR TITLE
access-management: deprecate broken new_request_for_resource + migrate type_name API

### DIFF
--- a/access-management/sources/access.move
+++ b/access-management/sources/access.move
@@ -135,13 +135,13 @@ public fun migrate_policy_version(policy: &mut Policy, admin: &PackageAdmin) {
 public fun claim_package<OTW: drop>(otw: OTW, ctx: &mut TxContext): PackageAdmin {
     assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
 
-    let `type` = type_name::get_with_original_ids<OTW>();
-    let module_name = `type`.get_module();
+    let `type` = type_name::with_original_ids<OTW>();
+    let module_name = `type`.module_string();
     assert!(module_name == ascii::string(b"access_init"), EClaimFromInvalidModule);
 
     PackageAdmin {
         id: object::new(ctx),
-        package: `type`.get_address(),
+        package: `type`.address_string(),
     }
 }
 
@@ -278,11 +278,11 @@ public fun add_action_to_rule<Action: drop>(
     check_version(policy);
     assert!(policy.package == admin.package, ENotPolicyAdmin);
 
-    let orig_package = type_name::get_with_original_ids<Action>().get_address();
+    let orig_package = type_name::with_original_ids<Action>().address_string();
     assert!(orig_package == admin.package, ENotActionAdmin);
 
     let rule = &mut policy.rules[&rule_id];
-    let action_name = type_name::get<Action>();
+    let action_name = type_name::with_defining_ids<Action>();
     rule.actions.insert(action_name);
 }
 
@@ -296,7 +296,7 @@ public fun remove_action_from_rule<Action: drop>(
     assert!(policy.package == admin.package, ENotPolicyAdmin);
 
     let rule = vec_map::get_mut(&mut policy.rules, &rule_id);
-    let action_name = type_name::get<Action>();
+    let action_name = type_name::with_defining_ids<Action>();
     rule.actions.remove(&action_name);
 }
 
@@ -313,7 +313,7 @@ public fun add_condition_to_rule_with_config<Condition: drop, Config: store + co
     assert!(policy.package == admin.package, ENotPolicyAdmin);
 
     let rule = vec_map::get_mut(&mut policy.rules, &rule_id);
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
     rule.conditions.insert(condition_name);
 
     rule.condition_configs.insert(condition_name, config);
@@ -345,7 +345,7 @@ public fun remove_condition_from_rule<Condition: drop>(
     assert!(policy.package == admin.package, ENotPolicyAdmin);
 
     let rule = &mut policy.rules[&rule_id];
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
     rule.condition_configs.remove<TypeName, ConfigNone>(condition_name);
 
     rule.conditions.remove(&condition_name);
@@ -365,7 +365,7 @@ public fun add_config_for_condition<Condition, Config: store + copy + drop>(
     assert!(policy.package == admin.package, ENotPolicyAdmin);
 
     let rule = &mut policy.rules[&rule_id];
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
 
     rule.condition_configs.remove<TypeName, ConfigNone>(condition_name);
     rule.condition_configs.insert(condition_name, config);
@@ -381,7 +381,7 @@ public fun remove_config_for_condition<Condition, Config: store + copy + drop>(
     assert!(policy.package == admin.package, ENotPolicyAdmin);
 
     let rule = &mut policy.rules[&rule_id];
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
 
     rule.condition_configs.remove<TypeName, Config>(condition_name);
     rule.condition_configs.insert(condition_name, ConfigNone {});
@@ -394,7 +394,7 @@ public fun borrow_condition_config<Condition, Config: store + copy + drop>(
 ): &Config {
     check_version(policy);
     let rule = &policy.rules[rule_id];
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
     &rule.condition_configs[condition_name]
 }
 
@@ -408,7 +408,7 @@ public fun borrow_mut_condition_config<Condition, Config: store + copy + drop>(
     assert!(policy.package == admin.package, ENotPolicyAdmin);
 
     let rule = &mut policy.rules[&rule_id];
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
 
     &mut rule.condition_configs[condition_name]
 }
@@ -418,7 +418,7 @@ public fun borrow_mut_condition_config<Condition, Config: store + copy + drop>(
 /// Creates a new action request.
 public fun new_request<Action: drop>(_: Action, ctx: &mut TxContext): ActionRequest {
     ActionRequest {
-        action_name: type_name::get<Action>(),
+        action_name: type_name::with_defining_ids<Action>(),
         context: dynamic_map::new(ctx),
         approved_conditions: vec_map::empty(),
     }
@@ -442,7 +442,7 @@ public fun new_request_with_context<Action: drop>(
     context: DynamicMap<std::ascii::String>,
 ): ActionRequest {
     ActionRequest {
-        action_name: type_name::get<Action>(),
+        action_name: type_name::with_defining_ids<Action>(),
         context,
         approved_conditions: vec_map::empty(),
     }
@@ -471,10 +471,10 @@ public fun get_condition_witness<Condition, Action: drop, Config: store + copy +
     assert!(policy.allowed_entities.contains(&object::id(entity)), EEntityNotAllowed);
 
     let rule = &policy.rules[&rule_id];
-    let action_name = type_name::get<Action>();
+    let action_name = type_name::with_defining_ids<Action>();
     assert!(rule.actions.contains(&action_name), EActionNotInRule);
 
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
     let config = rule.condition_configs[condition_name];
 
     ConditionWitness {
@@ -528,7 +528,7 @@ public fun approve_condition<Condition: drop, Config: store + copy + drop>(
     witness: &ConditionWitness<Condition, Config>,
     _: Condition,
 ) {
-    let condition_name = type_name::get<Condition>();
+    let condition_name = type_name::with_defining_ids<Condition>();
     request.approved_conditions.insert(condition_name, witness.rule_id);
 }
 
@@ -556,7 +556,7 @@ public fun approve_and_return_context(
     assert!(rule.actions.contains(&action_name), EActionNotInRule);
 
     let mut required_conditions = rule.conditions;
-    let size = required_conditions.size();
+    let size = required_conditions.length();
     let mut i = 0;
     while (i < size) {
         let (approved_condition_name, approved_rule_id) = approved_conditions.pop();
@@ -591,7 +591,7 @@ public fun admin_approve_request_and_return_context(
     request: ActionRequest,
     admin: &PackageAdmin,
 ): DynamicMap<String> {
-    let request_package = request.action_name.get_address();
+    let request_package = request.action_name.address_string();
     assert!(request_package == admin.package, ENotActionAdmin);
 
     let ActionRequest {
@@ -617,9 +617,9 @@ public fun admin_approve_request_with_original_id_and_return_context<Action: dro
     request: ActionRequest,
     admin: &PackageAdmin,
 ): DynamicMap<String> {
-    assert!(type_name::get<Action>() == request.action_name, EActionMismatch);
+    assert!(type_name::with_defining_ids<Action>() == request.action_name, EActionMismatch);
 
-    let orig_package = type_name::get_with_original_ids<Action>().get_address();
+    let orig_package = type_name::with_original_ids<Action>().address_string();
     assert!(orig_package == admin.package, ENotActionAdmin);
 
     let ActionRequest {
@@ -645,7 +645,7 @@ public fun admin_approve_request_with_original_id<Action: drop>(
 
 #[test_only]
 public fun create_admin_for_testing<W>(ctx: &mut TxContext): PackageAdmin {
-    let package = type_name::get_with_original_ids<W>().get_address();
+    let package = type_name::with_original_ids<W>().address_string();
     PackageAdmin {
         id: object::new(ctx),
         package,

--- a/access-management/sources/access.move
+++ b/access-management/sources/access.move
@@ -37,6 +37,8 @@ const EInvalidPolicyVersion: u64 = 8;
 const ENotUpgrade: u64 = 9;
 /// The action does not match the action in the request.
 const EActionMismatch: u64 = 10;
+/// The function is deprecated and disabled.
+const EDeprecated: u64 = 11;
 
 /* ================= constants ================= */
 
@@ -422,19 +424,16 @@ public fun new_request<Action: drop>(_: Action, ctx: &mut TxContext): ActionRequ
     }
 }
 
-/// Populates the context with the `resource_id` and `resource_type_name` fields
-/// for the provided resource.
+/// Deprecated: aborts. The `action: String` was discarded by the inner
+/// `new_request<Action: drop>` (inferred `Action = String`), so the
+/// resulting request was always unapproveable.
+#[deprecated(note = b"Aborts; action argument is discarded.")]
 public fun new_request_for_resource<T: key>(
-    action: String,
-    resource: &T,
-    ctx: &mut TxContext,
+    _: String,
+    _: &T,
+    _: &mut TxContext,
 ): ActionRequest {
-    let mut request = new_request(action, ctx);
-
-    request.context.insert(ascii::string(b"resource_id"), object::id(resource));
-    request.context.insert(ascii::string(b"resource_type_name"), type_name::get<T>());
-
-    request
+    abort EDeprecated
 }
 
 /// Creates a new action request with pre-populated context.

--- a/access-management/sources/access.move
+++ b/access-management/sources/access.move
@@ -96,7 +96,7 @@ public struct ActionRequest {
 }
 
 /// Carries condition configuration and context for condition approval functions.
-/// 
+///
 /// Type Parameters:
 /// - `Condition`: The condition type being witnessed
 /// - `Config`: Configuration data for the condition
@@ -112,7 +112,7 @@ public struct ConditionWitness<phantom Condition, Config: store + copy + drop> h
 }
 
 /// Represents a default configuration for a condition that does not require any additional configuration.
-public struct ConfigNone has store, copy, drop {}
+public struct ConfigNone has copy, drop, store {}
 
 /* ================= upgrade ================= */
 
@@ -130,7 +130,7 @@ public fun migrate_policy_version(policy: &mut Policy, admin: &PackageAdmin) {
 /* ================= package admin ================= */
 
 /// Claims package admin rights using a one-time witness.
-/// 
+///
 /// Aborts if the witness is not a valid one-time witness or if it does not originate from the expected module.
 public fun claim_package<OTW: drop>(otw: OTW, ctx: &mut TxContext): PackageAdmin {
     assert!(types::is_one_time_witness(&otw), ENotOneTimeWitness);
@@ -428,11 +428,7 @@ public fun new_request<Action: drop>(_: Action, ctx: &mut TxContext): ActionRequ
 /// `new_request<Action: drop>` (inferred `Action = String`), so the
 /// resulting request was always unapproveable.
 #[deprecated(note = b"Aborts; action argument is discarded.")]
-public fun new_request_for_resource<T: key>(
-    _: String,
-    _: &T,
-    _: &mut TxContext,
-): ActionRequest {
+public fun new_request_for_resource<T: key>(_: String, _: &T, _: &mut TxContext): ActionRequest {
     abort EDeprecated
 }
 

--- a/access-management/tests/access_tests.move
+++ b/access-management/tests/access_tests.move
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 module access_management::access_tests {
-    use sui::test_utils::destroy;
+    use std::unit_test::destroy;
     use std::ascii::{Self, String};
 
     use access_management::dynamic_map;

--- a/access-management/tests/access_tests.move
+++ b/access-management/tests/access_tests.move
@@ -1,234 +1,252 @@
 // Copyright (c) Kuna Labs d.o.o.
 // SPDX-License-Identifier: Apache-2.0
 
-module access_management::access_tests {
-    use std::unit_test::destroy;
-    use std::ascii::{Self, String};
+module access_management::access_tests;
 
-    use access_management::dynamic_map;
-    use access_management::access::{Self, ActionRequest, ConditionWitness, ConfigNone};
+use access_management::access::{Self, ActionRequest, ConditionWitness, ConfigNone};
+use access_management::dynamic_map;
+use std::ascii::{Self, String};
+use std::unit_test::destroy;
 
-    public struct ADMIN_WITNESS has drop { }
-    public struct ACTION has drop { }
-    public struct CONDITION has drop { }
+public struct ADMIN_WITNESS has drop {}
+public struct ACTION has drop {}
+public struct CONDITION has drop {}
 
-    public struct Config has copy, store, drop {
-        ignore_context: bool
+public struct Config has copy, drop, store {
+    ignore_context: bool,
+}
+
+fun approve_condition(
+    request: &mut ActionRequest,
+    witness: &ConditionWitness<CONDITION, ConfigNone>,
+) {
+    request.approve_condition(witness, CONDITION {});
+}
+
+fun approve_condition_with_config(
+    request: &mut ActionRequest,
+    witness: &ConditionWitness<CONDITION, Config>,
+) {
+    if (witness.config().ignore_context) {
+        request.approve_condition(witness, CONDITION {});
+        return
+    };
+
+    let allow = *request.context_value<bool>(ascii::string(b"allow"));
+    if (allow) {
+        request.approve_condition(witness, CONDITION {});
+    } else {
+        abort (0)
     }
+}
 
-    fun approve_condition (
-        request: &mut ActionRequest, witness: &ConditionWitness<CONDITION, ConfigNone>
-    ) {
-        request.approve_condition(witness, CONDITION { });
-    }
+#[test]
+fun test_action_request_success() {
+    let ctx = &mut tx_context::dummy();
 
-    fun approve_condition_with_config(
-        request: &mut ActionRequest, witness: &ConditionWitness<CONDITION, Config>
-    ) {
-        if (witness.config().ignore_context) {
-            request.approve_condition(witness, CONDITION { });
-            return
-        };
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    let mut policy = access::create_empty_policy(&admin, ctx);
+    let rule_id = policy.add_empty_rule(&admin, ctx);
+    policy.add_action_to_rule<ACTION>(&admin, rule_id);
 
-        let allow = *request.context_value<bool>(ascii::string(b"allow"));
-        if (allow) {
-            request.approve_condition(witness, CONDITION { });
-        } else {
-            abort(0)
-        }
-    }
+    let entity = access::create_entity(ctx);
+    policy.allowlist_entity(&admin, object::borrow_id(&entity));
 
-    #[test]
-    fun test_action_request_success() {
-        let ctx = &mut tx_context::dummy();
+    let request = access::new_request(ACTION {}, ctx);
+    access::approve_request(request, &entity, &policy, rule_id);
 
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        let mut policy = access::create_empty_policy(&admin, ctx);
-        let rule_id = policy.add_empty_rule(&admin, ctx);
-        policy.add_action_to_rule<ACTION>(&admin, rule_id);
+    destroy(admin);
+    destroy(policy);
+    destroy(entity);
+}
 
-        let entity = access::create_entity(ctx);
-        policy.allowlist_entity(&admin, object::borrow_id(&entity));
+#[test]
+#[expected_failure(abort_code = 5, location = access_management::access)]
+fun test_entity_not_allowed() {
+    let ctx = &mut tx_context::dummy();
 
-        let request = access::new_request(ACTION {}, ctx);
-        access::approve_request(request, &entity, &policy, rule_id);
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    let mut policy = access::create_empty_policy(&admin, ctx);
+    let rule_id = policy.add_empty_rule(&admin, ctx);
+    policy.add_action_to_rule<ACTION>(&admin, rule_id);
 
-        destroy(admin);
-        destroy(policy);
-        destroy(entity);
-    }
+    let entity = access::create_entity(ctx);
+    policy.allowlist_entity(&admin, object::borrow_id(&entity));
 
-    #[test]
-    #[expected_failure(abort_code = 5, location = access_management::access)]
-    fun test_entity_not_allowed() {
-        let ctx = &mut tx_context::dummy();
+    let request = access::new_request(ACTION {}, ctx);
+    let invalid_entity = access::create_entity(ctx);
+    access::approve_request(request, &invalid_entity, &policy, rule_id);
 
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        let mut policy = access::create_empty_policy(&admin, ctx);
-        let rule_id = policy.add_empty_rule(&admin, ctx);
-        policy.add_action_to_rule<ACTION>(&admin, rule_id);
+    destroy(admin);
+    destroy(policy);
+    destroy(entity);
+    destroy(invalid_entity);
+}
 
-        let entity = access::create_entity(ctx);
-        policy.allowlist_entity(&admin, object::borrow_id(&entity));
+#[test]
+fun test_success_with_condition() {
+    let ctx = &mut tx_context::dummy();
 
-        let request = access::new_request(ACTION {}, ctx);
-        let invalid_entity = access::create_entity(ctx);
-        access::approve_request(request, &invalid_entity, &policy, rule_id);
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    let mut policy = access::create_empty_policy(&admin, ctx);
+    let rule_id = policy.add_empty_rule(&admin, ctx);
+    access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
+    let entity = access::create_entity(ctx);
+    policy.allowlist_entity(&admin, object::borrow_id(&entity));
 
-        destroy(admin);
-        destroy(policy);
-        destroy(entity);
-        destroy(invalid_entity);
-    }
+    policy.add_condition_to_rule<CONDITION>(&admin, rule_id);
 
-    #[test]
-    fun test_success_with_condition() {
-        let ctx = &mut tx_context::dummy();
+    let mut request = access::new_request(ACTION {}, ctx);
+    let cw = policy.get_condition_witness<CONDITION, ACTION, ConfigNone>(&entity, rule_id);
 
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        let mut policy = access::create_empty_policy(&admin, ctx);
-        let rule_id = policy.add_empty_rule(&admin, ctx);
-        access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
-        let entity = access::create_entity(ctx);
-        policy.allowlist_entity(&admin, object::borrow_id(&entity));
+    approve_condition(&mut request, &cw);
+    access::approve_request(request, &entity, &policy, rule_id);
 
-        policy.add_condition_to_rule<CONDITION>(&admin, rule_id);
+    destroy(admin);
+    destroy(policy);
+    destroy(entity);
+}
 
-        let mut request = access::new_request(ACTION {}, ctx);
-        let cw = policy.get_condition_witness<CONDITION, ACTION, ConfigNone>(&entity, rule_id);
+#[test]
+#[expected_failure(abort_code = 4, location = sui::vec_map)]
+fun test_failure_condition_not_met() {
+    let ctx = &mut tx_context::dummy();
 
-        approve_condition(&mut request, &cw);
-        access::approve_request(request, &entity, &policy, rule_id);
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    let mut policy = access::create_empty_policy(&admin, ctx);
+    let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
+    access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
+    let entity = access::create_entity(ctx);
+    access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
 
-        destroy(admin);
-        destroy(policy);
-        destroy(entity); 
-    }
+    access::add_condition_to_rule<CONDITION>(&mut policy, &admin, rule_id);
 
-    #[test]
-    #[expected_failure(abort_code = 4, location = sui::vec_map)]
-    fun test_failure_condition_not_met() {
-        let ctx = &mut tx_context::dummy();
+    let request = access::new_request(ACTION {}, ctx);
+    access::approve_request(request, &entity, &policy, rule_id);
 
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        let mut policy = access::create_empty_policy(&admin, ctx);
-        let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
-        access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
-        let entity = access::create_entity(ctx);
-        access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
+    destroy(admin);
+    destroy(policy);
+    destroy(entity);
+}
 
-        access::add_condition_to_rule<CONDITION>(&mut policy, &admin, rule_id);
+#[test]
+fun test_success_with_condition_with_config() {
+    let ctx = &mut tx_context::dummy();
 
-        let request = access::new_request(ACTION {}, ctx);
-        access::approve_request(request, &entity, &policy, rule_id);
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    let mut policy = access::create_empty_policy(&admin, ctx);
+    let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
+    access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
+    let entity = access::create_entity(ctx);
+    access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
 
-        destroy(admin);
-        destroy(policy);
-        destroy(entity); 
-    }
+    let config = Config { ignore_context: true };
+    access::add_condition_to_rule_with_config<CONDITION, Config>(
+        &mut policy,
+        &admin,
+        rule_id,
+        config,
+    );
 
-    #[test]
-    fun test_success_with_condition_with_config() {
-        let ctx = &mut tx_context::dummy();
+    let mut request = access::new_request(ACTION {}, ctx);
+    let cw = access::get_condition_witness<CONDITION, ACTION, Config>(
+        &policy,
+        &entity,
+        rule_id,
+    );
 
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        let mut policy = access::create_empty_policy(&admin, ctx);
-        let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
-        access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
-        let entity = access::create_entity(ctx);
-        access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
+    approve_condition_with_config(&mut request, &cw);
+    access::approve_request(request, &entity, &policy, rule_id);
 
-        let config = Config { ignore_context: true };
-        access::add_condition_to_rule_with_config<CONDITION, Config>(
-            &mut policy, &admin, rule_id, config
-        );
+    destroy(admin);
+    destroy(policy);
+    destroy(entity);
+}
 
-        let mut request = access::new_request(ACTION {}, ctx);
-        let cw = access::get_condition_witness<CONDITION, ACTION, Config>(
-            &policy, &entity, rule_id
-        );
+#[test]
+fun test_success_with_condition_with_config_with_context() {
+    let ctx = &mut tx_context::dummy();
 
-        approve_condition_with_config(&mut request, &cw);
-        access::approve_request(request, &entity, &policy, rule_id);
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    let mut policy = access::create_empty_policy(&admin, ctx);
+    let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
+    access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
+    let entity = access::create_entity(ctx);
+    access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
 
-        destroy(admin);
-        destroy(policy);
-        destroy(entity); 
-    }
+    let config = Config { ignore_context: false };
+    access::add_condition_to_rule_with_config<CONDITION, Config>(
+        &mut policy,
+        &admin,
+        rule_id,
+        config,
+    );
 
-    #[test]
-    fun test_success_with_condition_with_config_with_context() {
-        let ctx = &mut tx_context::dummy();
+    let mut context = dynamic_map::new<String>(ctx);
+    dynamic_map::insert(&mut context, ascii::string(b"allow"), true);
+    let mut request = access::new_request_with_context(ACTION {}, context);
+    let cw = access::get_condition_witness<CONDITION, ACTION, Config>(
+        &policy,
+        &entity,
+        rule_id,
+    );
 
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        let mut policy = access::create_empty_policy(&admin, ctx);
-        let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
-        access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
-        let entity = access::create_entity(ctx);
-        access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
+    approve_condition_with_config(&mut request, &cw);
+    access::approve_request(request, &entity, &policy, rule_id);
 
-        let config = Config { ignore_context: false };
-        access::add_condition_to_rule_with_config<CONDITION, Config>(
-            &mut policy, &admin, rule_id, config
-        );
+    destroy(admin);
+    destroy(policy);
+    destroy(entity);
+}
 
-        let mut context = dynamic_map::new<String>(ctx);
-        dynamic_map::insert(&mut context, ascii::string(b"allow"), true);
-        let mut request = access::new_request_with_context(ACTION {}, context);
-        let cw = access::get_condition_witness<CONDITION, ACTION, Config>(
-            &policy, &entity, rule_id
-        );
+#[test]
+#[expected_failure(abort_code = 0, location = Self)]
+fun test_failure_with_condition_with_config_with_context() {
+    let ctx = &mut tx_context::dummy();
 
-        approve_condition_with_config(&mut request, &cw);
-        access::approve_request(request, &entity, &policy, rule_id);
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    let mut policy = access::create_empty_policy(&admin, ctx);
+    let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
+    access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
+    let entity = access::create_entity(ctx);
+    access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
 
-        destroy(admin);
-        destroy(policy);
-        destroy(entity); 
-    }
+    let config = Config { ignore_context: false };
+    access::add_condition_to_rule_with_config<CONDITION, Config>(
+        &mut policy,
+        &admin,
+        rule_id,
+        config,
+    );
 
-    #[test]
-    #[expected_failure(abort_code = 0, location = Self)]
-    fun test_failure_with_condition_with_config_with_context() {
-        let ctx = &mut tx_context::dummy();
+    let mut context = dynamic_map::new<String>(ctx);
+    dynamic_map::insert(&mut context, ascii::string(b"allow"), false);
+    let mut request = access::new_request_with_context(ACTION {}, context);
+    let cw = access::get_condition_witness<CONDITION, ACTION, Config>(
+        &policy,
+        &entity,
+        rule_id,
+    );
 
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        let mut policy = access::create_empty_policy(&admin, ctx);
-        let rule_id = access::add_empty_rule(&mut policy, &admin, ctx);
-        access::add_action_to_rule<ACTION>(&mut policy, &admin, rule_id);
-        let entity = access::create_entity(ctx);
-        access::allowlist_entity_for_policy(&mut policy, &admin, object::borrow_id(&entity));
+    approve_condition_with_config(&mut request, &cw);
+    access::approve_request(request, &entity, &policy, rule_id);
 
-        let config = Config { ignore_context: false };
-        access::add_condition_to_rule_with_config<CONDITION, Config>(
-            &mut policy, &admin, rule_id, config
-        );
+    destroy(admin);
+    destroy(policy);
+    destroy(entity);
+}
 
-        let mut context = dynamic_map::new<String>(ctx);
-        dynamic_map::insert(&mut context, ascii::string(b"allow"), false);
-        let mut request = access::new_request_with_context(ACTION {}, context);
-        let cw = access::get_condition_witness<CONDITION, ACTION, Config>(
-            &policy, &entity, rule_id
-        );
-
-        approve_condition_with_config(&mut request, &cw);
-        access::approve_request(request, &entity, &policy, rule_id);
-
-        destroy(admin);
-        destroy(policy);
-        destroy(entity);
-    }
-
-    #[test, expected_failure(abort_code = access::EDeprecated)]
-    #[allow(deprecated_usage)]
-    fun test_new_request_for_resource_aborts() {
-        let ctx = &mut tx_context::dummy();
-        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
-        destroy(access::new_request_for_resource(
+#[test, expected_failure(abort_code = access::EDeprecated)]
+#[allow(deprecated_usage)]
+fun test_new_request_for_resource_aborts() {
+    let ctx = &mut tx_context::dummy();
+    let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+    destroy(
+        access::new_request_for_resource(
             ascii::string(b"transfer"),
             &admin,
             ctx,
-        ));
-        destroy(admin);
-    }
+        ),
+    );
+    destroy(admin);
 }

--- a/access-management/tests/access_tests.move
+++ b/access-management/tests/access_tests.move
@@ -216,6 +216,19 @@ module access_management::access_tests {
 
         destroy(admin);
         destroy(policy);
-        destroy(entity); 
+        destroy(entity);
+    }
+
+    #[test, expected_failure(abort_code = access::EDeprecated)]
+    #[allow(deprecated_usage)]
+    fun test_new_request_for_resource_aborts() {
+        let ctx = &mut tx_context::dummy();
+        let admin = access::create_admin_for_testing<ADMIN_WITNESS>(ctx);
+        destroy(access::new_request_for_resource(
+            ascii::string(b"transfer"),
+            &admin,
+            ctx,
+        ));
+        destroy(admin);
     }
 }


### PR DESCRIPTION
## Summary

Audit-driven changes to `access-management`.

### [Medium] Deprecate `new_request_for_resource` (silently broken)

`new_request_for_resource(action: String, ...)` takes the action as a `String` and passes it to `new_request<Action: drop>`, which infers `Action = std::ascii::String`. The string argument is dropped, and the resulting `request.action_name` is `type_name::with_defining_ids<std::ascii::String>()` for every call — regardless of which action the caller intended. Requests built this way are unapproveable via the standard admin path because the policy never has a rule whose action type is `std::ascii::String`.

**Fix**: signature preserved so the on-chain package upgrade compatibility check still accepts the new version. The function is annotated `#[deprecated]` and the body replaced with `abort EDeprecated`. Callers now see `W04037` plus a runtime abort instead of a silently broken request. A typed-witness replacement (`new_request_with_resource<Action: drop>`) can be added later when an actual use case appears. Regression test `test_new_request_for_resource_aborts` confirms the abort.

### Migrate to non-deprecated `type_name` API

The Sui stdlib deprecated `type_name::get*` and the legacy accessor methods. Behavior-preserving renames across `access.move`:

- `type_name::get_with_original_ids<T>()` → `with_original_ids<T>()`
- `type_name::get<T>()` → `with_defining_ids<T>()`
- `<TypeName>.get_address()` → `.address_string()`
- `<TypeName>.get_module_string()` → `.module_string()`

### Test cleanup

- `sui::test_utils::destroy` → `std::unit_test::destroy` in `access_tests.move` (`W04037`).
- Formatter pass on `access.move` and `access_tests.move`.

## Test plan

- [x] `sui move test --path access-management` — 8 tests pass
- [x] New regression test for the deprecated function's abort
- [x] No new build warnings