### PR TITLE
kai-leverage: fix assets_x128 precedence bug + build-warning cleanup

### DIFF
--- a/kai/leverage/core/sources/clmm/position_core.move
+++ b/kai/leverage/core/sources/clmm/position_core.move
@@ -3206,7 +3206,7 @@ public(package) macro fun add_liquidity_inner<$X, $Y, $Pool, $LP>(
         $pool_object,
         |pool, lp_position| {
             let (delta_l, delta_x, delta_y) = $add_liquidity_inner(pool, lp_position);
-            (delta_l, delta_x, delta_y, 0)
+            (delta_l, delta_x, delta_y, false)
         },
     );
     info

--- a/kai/leverage/core/sources/clmm/position_model.move
+++ b/kai/leverage/core/sources/clmm/position_model.move
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Mathematical model for leveraged CLMM position analysis implementing formal theoretical guarantees.
-/// 
-/// This module implements the mathematical framework from "Concentrated Liquidity with Leverage" 
+///
+/// This module implements the mathematical framework from "Concentrated Liquidity with Leverage"
 /// ([arXiv:2409.12803](https://arxiv.org/pdf/2409.12803)), providing analytical functions for position
 /// valuation, risk assessment, and safety validation with formal mathematical proofs.
-/// 
+///
 /// ## Theoretical Foundation
-/// 
+///
 /// The module implements key mathematical concepts from the paper:
 /// - **Position Value**: V_pos(P) = L·f(P, p_a, p_b) where f varies by price range
 /// - **Asset Value**: A(P) = V_pos(P) + x_C·P + y_C (total position assets)
@@ -168,7 +168,7 @@ public fun assets_x128(self: &PositionModel, p_x128: u256): u256 {
     let y_x64 = (y_x64(self, sqrt_p_x64) as u256);
     let x_x64 = (x_x64(self, sqrt_p_x64) as u256);
 
-    (x_x64 + cx_x64) * p_x64 + (y_x64 + cy_x64) << 64
+    (x_x64 + cx_x64) * p_x64 + ((y_x64 + cy_x64) << 64)
 }
 
 /// Calculate the value of debt for the position for a given price, expressed in Y.
@@ -616,6 +616,68 @@ public fun calc_liquidate_col_y(
         ) as u64;
 
     (repayment_amt_x, reward_amt_y)
+}
+
+#[test]
+fun test_assets_x128() {
+    let sqrt_pa_x64: u128 = 17499818628114608849; // ~0.9
+    let sqrt_pb_x64: u128 = 26086568254500584001; // ~2
+
+    // l = 0, cx-only at p = 2.0 → assets = 200, in Q.128.
+    let position = PositionModel {
+        sqrt_pa_x64,
+        sqrt_pb_x64,
+        l: 0,
+        cx: 100,
+        cy: 0,
+        dx: 0,
+        dy: 0,
+    };
+    assert!(assets_x128(&position, 2u256 << 128) == 200u256 << 128);
+
+    // l = 0, cx + cy at p = 2.0 → assets = 250, in Q.128.
+    let position = PositionModel {
+        sqrt_pa_x64,
+        sqrt_pb_x64,
+        l: 0,
+        cx: 100,
+        cy: 50,
+        dx: 0,
+        dy: 0,
+    };
+    assert!(assets_x128(&position, 2u256 << 128) == 250u256 << 128);
+
+    // Non-trivial l with no collateral, p = 1.5 (test_margin setup).
+    // Expected pre-computed offline.
+    let position = PositionModel {
+        sqrt_pa_x64,
+        sqrt_pb_x64,
+        l: 3902203900,
+        cx: 0,
+        cy: 0,
+        dx: 0,
+        dy: 0,
+    };
+    let p_x128: u256 = (15u256 << 128) / 10;
+    assert!(
+        assets_x128(&position, p_x128) ==
+            584412669613635029870188263695711999023516745728,
+    );
+
+    // Non-trivial l + cx + cy at p = 1.5. Expected pre-computed offline.
+    let position = PositionModel {
+        sqrt_pa_x64,
+        sqrt_pb_x64,
+        l: 3902203900,
+        cx: 100,
+        cy: 50,
+        dx: 0,
+        dy: 0,
+    };
+    assert!(
+        assets_x128(&position, p_x128) ==
+            584412737670108414057880956370633485377159036928,
+    );
 }
 
 #[test]

--- a/kai/leverage/core/sources/primitives/debt.move
+++ b/kai/leverage/core/sources/primitives/debt.move
@@ -104,6 +104,7 @@ public fun create_registry_with_cap<T: drop>(_: &TreasuryCap<T>): DebtRegistry<T
 }
 
 /// Create a new debt treasury. The treasury has the ability to mint debt as fungible coins.
+#[deprecated(note = b"TODO: migrate currency creation to `coin_registry`")]
 public fun create_treasury<T: drop>(
     witness: T,
     decimals: u8,

--- a/kai/leverage/core/sources/primitives/equity.move
+++ b/kai/leverage/core/sources/primitives/equity.move
@@ -103,6 +103,7 @@ public fun create_registry_with_cap<T: drop>(_: &TreasuryCap<T>): EquityRegistry
 }
 
 /// Create a new equity treasury. The treasury has the ability to mint equity as fungible coins.
+#[deprecated(note = b"TODO: migrate currency creation to `coin_registry`")]
 public fun create_treasury<T: drop>(
     witness: T,
     decimals: u8,

--- a/kai/leverage/core/sources/util.move
+++ b/kai/leverage/core/sources/util.move
@@ -39,7 +39,7 @@ public fun saturating_muldiv_round_up_u128(a: u128, b: u128, c: u128): u128 {
         (c as u256),
     );
     if (res > (1 << 128) - 1) {
-        ((1 << 128) - 1) as u128
+        (1 << 128) - 1u128
     } else {
         res as u128
     }

--- a/kai/leverage/core/tests/position_core/bluefin/deleverage_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/bluefin/deleverage_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_bluefin_deleverage_standard_flow_tests;
 
 use kai_leverage::position_core_bluefin_test_setup;
 use kai_leverage::position_core_deleverage_standard_flow_test_macros as macros;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun deleverage_with_ticket_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/bluefin/liquidate_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/bluefin/liquidate_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_bluefin_liquidate_standard_flow_tests;
 
 use kai_leverage::position_core_bluefin_test_setup;
 use kai_leverage::position_core_liquidate_standard_flow_test_macros as macros;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun liquidate_col_x_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/bluefin/repay_bad_debt_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/bluefin/repay_bad_debt_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_bluefin_repay_bad_debt_standard_flow_tests;
 
 use kai_leverage::position_core_bluefin_test_setup;
 use kai_leverage::position_core_repay_bad_debt_standard_flow_test_macros as macros;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun repay_bad_debt_x_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/bluefin/setup.move
+++ b/kai/leverage/core/tests/position_core/bluefin/setup.move
@@ -42,7 +42,7 @@ use sui::clock::{Self, Clock};
 use sui::coin;
 use sui::sui::SUI;
 use sui::test_scenario::{Self, Scenario, TransactionEffects};
-use sui::test_utils::destroy as destroy_;
+use std::unit_test::destroy as destroy_;
 use usdc::usdc::USDC;
 
 const INITIAL_CLOCK_TIMESTAMP_MS: u64 = 1755000000000;

--- a/kai/leverage/core/tests/position_core/cetus/deleverage_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/cetus/deleverage_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_cetus_deleverage_standard_flow_tests;
 
 use kai_leverage::position_core_cetus_test_setup;
 use kai_leverage::position_core_deleverage_standard_flow_test_macros as macros;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun deleverage_with_ticket_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/cetus/liquidate_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/cetus/liquidate_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_cetus_liquidate_standard_flow_tests;
 
 use kai_leverage::position_core_cetus_test_setup;
 use kai_leverage::position_core_liquidate_standard_flow_test_macros as macros;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun liquidate_col_x_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/cetus/repay_bad_debt_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/cetus/repay_bad_debt_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_cetus_repay_bad_debt_standard_flow_tests;
 
 use kai_leverage::position_core_cetus_test_setup;
 use kai_leverage::position_core_repay_bad_debt_standard_flow_test_macros as macros;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun repay_bad_debt_x_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/cetus/setup.move
+++ b/kai/leverage/core/tests/position_core/cetus/setup.move
@@ -38,7 +38,7 @@ use sui::balance::{Self, Balance};
 use sui::clock::{Self, Clock};
 use sui::sui::SUI;
 use sui::test_scenario::{Self, Scenario, TransactionEffects};
-use sui::test_utils::destroy as destroy_;
+use std::unit_test::destroy as destroy_;
 use usdc::usdc::USDC;
 
 const INITIAL_CLOCK_TIMESTAMP_MS: u64 = 1755000000000;

--- a/kai/leverage/core/tests/position_core/get_balance_ema_usd_value_6_decimals_tests.move
+++ b/kai/leverage/core/tests/position_core/get_balance_ema_usd_value_6_decimals_tests.move
@@ -9,7 +9,7 @@ use std::type_name::{Self, TypeName};
 use sui::balance;
 use sui::clock::{Self, Clock};
 use sui::sui::SUI;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use sui::vec_map;
 use usdc::usdc::USDC;
 

--- a/kai/leverage/core/tests/position_core/macros/create_position.move
+++ b/kai/leverage/core/tests/position_core/macros/create_position.move
@@ -10,7 +10,7 @@ use kai_leverage::position_core_test_util::{
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 use sui::bcs;
 

--- a/kai/leverage/core/tests/position_core/macros/deleverage.move
+++ b/kai/leverage/core/tests/position_core/macros/deleverage.move
@@ -9,7 +9,7 @@ use std::u128;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use kai_leverage::supply_pool_tests::{SSUI, SUSDC};
 use usdc::usdc::USDC;
 

--- a/kai/leverage/core/tests/position_core/macros/deleverage_standard_flow.move
+++ b/kai/leverage/core/tests/position_core/macros/deleverage_standard_flow.move
@@ -13,7 +13,7 @@ use std::u128;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 
 // cetus

--- a/kai/leverage/core/tests/position_core/macros/liquidate.move
+++ b/kai/leverage/core/tests/position_core/macros/liquidate.move
@@ -12,7 +12,7 @@ use std::u64;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 
 // cetus

--- a/kai/leverage/core/tests/position_core/macros/liquidate_standard_flow.move
+++ b/kai/leverage/core/tests/position_core/macros/liquidate_standard_flow.move
@@ -14,7 +14,7 @@ use std::u64;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 
 // cetus

--- a/kai/leverage/core/tests/position_core/macros/liquidate_standard_flow.move
+++ b/kai/leverage/core/tests/position_core/macros/liquidate_standard_flow.move
@@ -9,7 +9,6 @@ use kai_leverage::position_core_test_util::{
 };
 use kai_leverage::util;
 use std::type_name;
-use std::u256;
 use std::u64;
 use sui::balance;
 use sui::sui::SUI;
@@ -446,7 +445,7 @@ public macro fun liquidate_col_y_standard_flow<$Setup>($setup: &mut $Setup): Pos
             let repayment_value_with_bonus_x64 =
                 (debt_value_x64 * ((1 << 64) + liq_bonus_x64)) >> 64;
 
-            u256::divide_and_round_up(repayment_value_with_bonus_x64, 1 << 64) as u64
+            repayment_value_with_bonus_x64.div_ceil(1 << 64) as u64
         };
         let exp_fee_amt_y = util::muldiv(
             exp_reward_amt_y,

--- a/kai/leverage/core/tests/position_core/macros/repay_bad_debt.move
+++ b/kai/leverage/core/tests/position_core/macros/repay_bad_debt.move
@@ -11,7 +11,7 @@ use std::u64;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 
 // cetus

--- a/kai/leverage/core/tests/position_core/macros/repay_bad_debt_standard_flow.move
+++ b/kai/leverage/core/tests/position_core/macros/repay_bad_debt_standard_flow.move
@@ -13,7 +13,7 @@ use std::u64;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 
 // cetus

--- a/kai/leverage/core/tests/position_core/macros/standard_flow.move
+++ b/kai/leverage/core/tests/position_core/macros/standard_flow.move
@@ -15,7 +15,6 @@ use kai_leverage::position_core_test_util::{
 use kai_leverage::pyth;
 use kai_leverage::supply_pool_tests::{SSUI, SUSDC};
 use std::type_name;
-use std::u128;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
@@ -51,7 +50,7 @@ public fun calc_expected_debt(
 ): u64 {
     let seconds_in_year = 365 * 24 * 60 * 60;
     let accrued = (initial_debt_x64 * seconds_passed * interest_pct) / 100 / seconds_in_year;
-    u128::divide_and_round_up(initial_debt_x64 + accrued, q64!()) as u64
+    (initial_debt_x64 + accrued).div_ceil(q64!()) as u64
 }
 
 public macro fun create_position<$Setup>($setup: &mut $Setup): PositionCap {

--- a/kai/leverage/core/tests/position_core/macros/standard_flow.move
+++ b/kai/leverage/core/tests/position_core/macros/standard_flow.move
@@ -697,8 +697,9 @@ public macro fun close_position<$Setup>(
 
         // check rate limiter after position reduction
         let limiter = config.borrow_create_withdraw_limiter();
-        let inflow_from_creation = 450_000000;
-        assert!(limiter.inflow_total() == inflow_from_creation);
+        // The inflow from position creation has rolled out of the 1-hour
+        // sliding window after the ~2.8-hour clock advance above.
+        assert!(limiter.inflow_total() == 0);
 
         let validated_price_info = core::validate_price_info(&config, &setup.price_info());
         let withdrawn_x_value = core::get_amount_ema_usd_value_6_decimals<SUI>(
@@ -725,7 +726,7 @@ public macro fun close_position<$Setup>(
             (withdrawn_x_value + withdrawn_y_value) - (repaid_x_value + repaid_y_value);
         assert!(limiter.outflow_total() == (expected_outflow as u256));
         let (net_amount, is_outflow) = limiter.net_value();
-        assert!(net_amount == (expected_outflow as u256) - inflow_from_creation);
+        assert!(net_amount == (expected_outflow as u256));
         assert!(is_outflow == true);
 
         // repay ticket

--- a/kai/leverage/core/tests/position_core/macros/standard_flow.move
+++ b/kai/leverage/core/tests/position_core/macros/standard_flow.move
@@ -19,7 +19,7 @@ use std::u128;
 use sui::balance;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 
 // cetus

--- a/kai/leverage/core/tests/position_core/mock_dex/deleverage_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/mock_dex/deleverage_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_mock_dex_deleverage_standard_flow_tests;
 
 use kai_leverage::position_core_deleverage_standard_flow_test_macros as macros;
 use kai_leverage::position_core_mock_dex_test_setup;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun deleverage_with_ticket_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/mock_dex/liquidate_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/mock_dex/liquidate_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_mock_dex_liquidate_standard_flow_tests;
 
 use kai_leverage::position_core_liquidate_standard_flow_test_macros as macros;
 use kai_leverage::position_core_mock_dex_test_setup;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun liquidate_col_x_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/mock_dex/repay_bad_debt_standard_flow_tests.move
+++ b/kai/leverage/core/tests/position_core/mock_dex/repay_bad_debt_standard_flow_tests.move
@@ -3,7 +3,7 @@ module kai_leverage::position_core_mock_dex_repay_bad_debt_standard_flow_tests;
 
 use kai_leverage::position_core_mock_dex_test_setup;
 use kai_leverage::position_core_repay_bad_debt_standard_flow_test_macros as macros;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun repay_bad_debt_x_standard_flow_is_correct() {

--- a/kai/leverage/core/tests/position_core/mock_dex/setup.move
+++ b/kai/leverage/core/tests/position_core/mock_dex/setup.move
@@ -35,7 +35,7 @@ use sui::balance::{Self, Balance};
 use sui::clock::{Self, Clock};
 use sui::sui::SUI;
 use sui::test_scenario::{Self, Scenario, TransactionEffects};
-use sui::test_utils::destroy as destroy_;
+use std::unit_test::destroy as destroy_;
 use usdc::usdc::USDC;
 
 const INITIAL_CLOCK_TIMESTAMP_MS: u64 = 1755000000000;

--- a/kai/leverage/core/tests/position_core/price_deviation_is_acceptable_tests.move
+++ b/kai/leverage/core/tests/position_core/price_deviation_is_acceptable_tests.move
@@ -5,7 +5,7 @@ use kai_leverage::position_core_clmm as core;
 use kai_leverage::position_core_test_util;
 use sui::clock;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 
 #[test]
 fun test_price_deviation_is_acceptable() {

--- a/kai/leverage/core/tests/supply_pool_tests.move
+++ b/kai/leverage/core/tests/supply_pool_tests.move
@@ -7,7 +7,7 @@ use sui::balance;
 use sui::clock::Clock;
 use sui::sui::SUI;
 use sui::test_scenario;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use usdc::usdc::USDC;
 
 public struct SSUI has drop {}

--- a/kai/leverage/supply-pool-init/deep/sources/klsp_deep.move
+++ b/kai/leverage/supply-pool-init/deep/sources/klsp_deep.move
@@ -9,6 +9,7 @@ use deep::deep::DEEP;
 
 public struct KLDEEP has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLDEEP, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klDEEP";

--- a/kai/leverage/supply-pool-init/lbtc/sources/klsp_lbtc.move
+++ b/kai/leverage/supply-pool-init/lbtc/sources/klsp_lbtc.move
@@ -9,6 +9,7 @@ use lbtc::lbtc::LBTC;
 
 public struct KLLBTC has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLLBTC, ctx: &mut TxContext) {
     let decimals = 8;
     let symbol = b"klLBTC";

--- a/kai/leverage/supply-pool-init/paused-suiusdt/sources/klsp_suiusdt.move
+++ b/kai/leverage/supply-pool-init/paused-suiusdt/sources/klsp_suiusdt.move
@@ -9,6 +9,7 @@ use suiusdt::usdt::USDT as SUIUSDT;
 
 public struct KLSUIUSDT has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLSUIUSDT, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klsuiUSDT";

--- a/kai/leverage/supply-pool-init/paused-usdc/sources/klsp_usdc.move
+++ b/kai/leverage/supply-pool-init/paused-usdc/sources/klsp_usdc.move
@@ -9,6 +9,7 @@ use usdc::usdc::USDC;
 
 public struct KLUSDC has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLUSDC, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klUSDC";

--- a/kai/leverage/supply-pool-init/sui/sources/klsp_sui.move
+++ b/kai/leverage/supply-pool-init/sui/sources/klsp_sui.move
@@ -9,6 +9,7 @@ use sui::sui::SUI;
 
 public struct KLSUI has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLSUI, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klSUI";

--- a/kai/leverage/supply-pool-init/suiusdt/sources/klsp_suiusdt.move
+++ b/kai/leverage/supply-pool-init/suiusdt/sources/klsp_suiusdt.move
@@ -9,6 +9,7 @@ use suiusdt::usdt::USDT as SUIUSDT;
 
 public struct KLSUIUSDT has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLSUIUSDT, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klsuiUSDT-2";

--- a/kai/leverage/supply-pool-init/usdc/sources/klsp_usdc.move
+++ b/kai/leverage/supply-pool-init/usdc/sources/klsp_usdc.move
@@ -9,6 +9,7 @@ use usdc::usdc::USDC;
 
 public struct KLUSDC has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLUSDC, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klUSDC-2";

--- a/kai/leverage/supply-pool-init/usdy/sources/klsp_usdy.move
+++ b/kai/leverage/supply-pool-init/usdy/sources/klsp_usdy.move
@@ -9,6 +9,7 @@ use usdy::usdy::USDY;
 
 public struct KLUSDY has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLUSDY, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klUSDY";

--- a/kai/leverage/supply-pool-init/wal/sources/klsp_wal.move
+++ b/kai/leverage/supply-pool-init/wal/sources/klsp_wal.move
@@ -9,6 +9,7 @@ use wal::wal::WAL;
 
 public struct KLWAL has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLWAL, ctx: &mut TxContext) {
     let decimals = 9;
     let symbol = b"klWAL";

--- a/kai/leverage/supply-pool-init/wbtc/sources/klsp_wbtc.move
+++ b/kai/leverage/supply-pool-init/wbtc/sources/klsp_wbtc.move
@@ -9,6 +9,7 @@ use wbtc::btc::BTC as WBTC;
 
 public struct KLWBTC has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLWBTC, ctx: &mut TxContext) {
     let decimals = 8;
     let symbol = b"klWBTC";

--- a/kai/leverage/supply-pool-init/whusdce/sources/klsp_whusdce.move
+++ b/kai/leverage/supply-pool-init/whusdce/sources/klsp_whusdce.move
@@ -9,6 +9,7 @@ use whusdce::coin::COIN as WHUSDCE;
 
 public struct KLWHUSDCE has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLWHUSDCE, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klWHUSDCE";

--- a/kai/leverage/supply-pool-init/whusdte/sources/klsp_whusdte.move
+++ b/kai/leverage/supply-pool-init/whusdte/sources/klsp_whusdte.move
@@ -9,6 +9,7 @@ use whusdte::coin::COIN as WHUSDTE;
 
 public struct KLWHUSDTE has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLWHUSDTE, ctx: &mut TxContext) {
     let decimals = 6;
     let symbol = b"klWHUSDTE";

--- a/kai/leverage/supply-pool-init/xbtc/sources/klsp_xbtc.move
+++ b/kai/leverage/supply-pool-init/xbtc/sources/klsp_xbtc.move
@@ -9,6 +9,7 @@ use xbtc::xbtc::XBTC;
 
 public struct KLXBTC has drop {}
 
+#[allow(deprecated_usage)]
 fun init(w: KLXBTC, ctx: &mut TxContext) {
     let decimals = 8;
     let symbol = b"klXBTC";

--- a/kai/sav/core/tests/rate_limit_tests.move
+++ b/kai/sav/core/tests/rate_limit_tests.move
@@ -11,7 +11,7 @@ use sui::balance;
 use sui::clock::{Self, Clock};
 use sui::coin;
 use sui::sui::SUI;
-use sui::test_utils::destroy;
+use std::unit_test::destroy;
 use sui::test_scenario::{Self as scenario};
 
 public struct YSUI has drop {}


### PR DESCRIPTION
## Summary

Audit-driven fix to `kai-leverage` plus follow-on cleanup.

### [Medium] `assets_x128` precedence bug

`position_model::assets_x128` returned a value off by ~2^64 in the dominant term. The expression `(x_x64 + cx_x64) * p_x64 + (y_x64 + cy_x64) << 64` parses as `((x_x64 + cx_x64) * p_x64 + (y_x64 + cy_x64)) << 64` in Move because `<<` (precedence 8) binds looser than `+` (precedence 9). The intended precedence is `(x_x64 + cx_x64) * p_x64 + ((y_x64 + cy_x64) << 64)`.

Fix: inner parens around the y-term shift. Added `test_assets_x128` with four cases covering `cx`-only, `cx + cy`, `l > 0` no collateral, and `l > 0 + cx + cy`. Expected values were precomputed in Python so the test fails on the pre-fix code with a multi-order-of-magnitude mismatch and passes on the fix.

**Impact**: off-chain only. `assets_x128` is consumed by the off-chain TypeScript SDKs (`cli-tool`, `sdk`, `shared`), not by on-chain margin or liquidation logic. On-chain margin uses `margin_x64`, which is unaffected.

### Follow-on changes

- `standard_flow` macro assertion update: after PR #18's rate-limiter fix, `consume_*` advances both sides on every call, so `inflow_total()` reflects the actual sliding-window state. The macro advances the clock ~2.8 hours past the 1-hour window between position creation and reduce, so the position-creation inflow rolls out and is no longer counted. Updated the assertions to expect `inflow_total = 0` and `net_amount = expected_outflow`.
- Test cleanup: `sui::test_utils::destroy` → `std::unit_test::destroy` across leverage-core test files plus `sav-core/tests/rate_limit_tests.move` (`W04037`).
- Build-warning cleanup: rename `divide_and_round_up` → `div_ceil` at two call sites (per stdlib rename); wrap `equity::create_treasury` and `debt::create_treasury` in `#[deprecated(note = ...)]` to defer the non-trivial migration to `coin_registry::new_currency_with_otw`; anchor a `1 << 128` literal type up-front; fix a `bool` tuple-constructor type mismatch.
- Supply-pool-init suppression: each of the 13 per-asset wrappers calls `equity::create_treasury` / `debt::create_treasury` in its `init`, which now triggers `W04037`. Added `#[allow(deprecated_usage)]` on each `fun init` so the wrappers stay clean while the underlying `coin_registry` migration remains pending.

## Test plan

- [x] `sui move test --path kai/leverage/core` — 303 tests pass (private repo equivalent; includes the four new `test_assets_x128` cases)
- [x] `sui move test --path kai/sav/core` — 42 tests pass (private repo equivalent)
- [x] `sui move build` succeeds for `kai/leverage/core` and all 13 supply-pool-init wrappers, no new warnings
- [ ] Coordinated SDK update needed for `assets_x128` consumers (`cli-tool`, `sdk`, `shared`) — handled separately