### PR TITLE
move: regenerate lockfiles for mainnet and testnet

### DIFF
--- a/_vendor/Bluefin/integer-library-v3/Move.lock
+++ b/_vendor/Bluefin/integer-library-v3/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.integer_library]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Bluefin/spot-v17/Move.lock
+++ b/_vendor/Bluefin/spot-v17/Move.lock
@@ -33,3 +33,33 @@ source = { local = "../../Cetus/integer-mate-v5" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.bluefin_spot]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Cetus/clmm-v13/Move.lock
+++ b/_vendor/Cetus/clmm-v13/Move.lock
@@ -33,3 +33,33 @@ source = { local = "../move-stl-v5" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.cetus_clmm]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Cetus/farming-v9/Move.lock
+++ b/_vendor/Cetus/farming-v9/Move.lock
@@ -39,3 +39,39 @@ source = { local = "../move-stl-v5" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_farming]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "8DB158090AFF5CFE23E583AEC9A22C651155612065FEC356DA74C639F67B5231"
+deps = { cetus_clmm = "cetus_clmm", integer_mate = "integer_mate", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Cetus/integer-mate-v5/Move.lock
+++ b/_vendor/Cetus/integer-mate-v5/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.integer_mate]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Cetus/integer-mate-v7/Move.lock
+++ b/_vendor/Cetus/integer-mate-v7/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.integer_mate]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Cetus/integrate-v15/Move.lock
+++ b/_vendor/Cetus/integrate-v15/Move.lock
@@ -45,3 +45,45 @@ source = { local = "../move-stl-v5" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_farming]
+source = { local = "../farming-v9" }
+use_environment = "testnet"
+manifest_digest = "8DB158090AFF5CFE23E583AEC9A22C651155612065FEC356DA74C639F67B5231"
+deps = { cetus_clmm = "cetus_clmm", integer_mate = "integer_mate", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_integrate]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "9404C2C940A560D5834D7B47CF2F9B407AE67FEF54035DD13DAF84037810AD26"
+deps = { cetus_clmm = "cetus_clmm", cetus_farming = "cetus_farming", integer_mate = "integer_mate", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Cetus/move-stl-v5/Move.lock
+++ b/_vendor/Cetus/move-stl-v5/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.move_stl]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Circle/stablecoin-v1/Move.lock
+++ b/_vendor/Circle/stablecoin-v1/Move.lock
@@ -27,3 +27,27 @@ source = { local = "../sui-extensions-v1" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.stablecoin]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Circle/sui-extensions-v1/Move.lock
+++ b/_vendor/Circle/sui-extensions-v1/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.sui_extensions]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Pyth/core-v2/Move.lock
+++ b/_vendor/Pyth/core-v2/Move.lock
@@ -27,3 +27,27 @@ source = { local = "../../Wormhole/core-v1" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.pyth]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Scallop/coin-decimals-registry-v1/Move.lock
+++ b/_vendor/Scallop/coin-decimals-registry-v1/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.coin_decimals_registry]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Scallop/math-v1/Move.lock
+++ b/_vendor/Scallop/math-v1/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.math]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Scallop/protocol-v10/Move.lock
+++ b/_vendor/Scallop/protocol-v10/Move.lock
@@ -51,3 +51,51 @@ source = { local = "../x-oracle-v1" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.coin_decimals_registry]
+source = { local = "../coin-decimals-registry-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.math]
+source = { local = "../math-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.protocol]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "3D851B35976E357336D49227D57B4E39D10197D63AD13BEA3EE180A3C85C69E6"
+deps = { coin_decimals_registry = "coin_decimals_registry", math = "math", std = "MoveStdlib", sui = "Sui", whitelist = "whitelist", x = "x", x_oracle = "x_oracle" }
+
+[pinned.testnet.whitelist]
+source = { local = "../whitelist-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.x]
+source = { local = "../x-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.x_oracle]
+source = { local = "../x-oracle-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Scallop/spool-v2/Move.lock
+++ b/_vendor/Scallop/spool-v2/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.spool]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Scallop/whitelist-v1/Move.lock
+++ b/_vendor/Scallop/whitelist-v1/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.whitelist]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Scallop/x-oracle-v1/Move.lock
+++ b/_vendor/Scallop/x-oracle-v1/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.x_oracle]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Scallop/x-v1/Move.lock
+++ b/_vendor/Scallop/x-v1/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.x]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Wormhole/core-v1/Move.lock
+++ b/_vendor/Wormhole/core-v1/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.wormhole]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/Wormhole/token-bridge-v1/Move.lock
+++ b/_vendor/Wormhole/token-bridge-v1/Move.lock
@@ -27,3 +27,27 @@ source = { local = "../core-v1" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.token_bridge]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.wormhole]
+source = { local = "../core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/DEEP/Move.lock
+++ b/_vendor/coins/DEEP/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.deep]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/LBTC/Move.lock
+++ b/_vendor/coins/LBTC/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.lbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/USDC/Move.lock
+++ b/_vendor/coins/USDC/Move.lock
@@ -33,3 +33,33 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "AEB379AEE1A925ED5C021ADE30219DD4456B0B776416B0F3BB7630346DCE7E1E"
 deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.usdc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }

--- a/_vendor/coins/USDY/Move.lock
+++ b/_vendor/coins/USDY/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.usdy]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/WAL/Move.lock
+++ b/_vendor/coins/WAL/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.wal]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/suiUSDT/Move.lock
+++ b/_vendor/coins/suiUSDT/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.suiusdt]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/wBTC/Move.lock
+++ b/_vendor/coins/wBTC/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.wbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/whUSDCe/Move.lock
+++ b/_vendor/coins/whUSDCe/Move.lock
@@ -33,3 +33,33 @@ source = { local = "../../Wormhole/core-v1" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.whusdce]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/whUSDTe/Move.lock
+++ b/_vendor/coins/whUSDTe/Move.lock
@@ -33,3 +33,33 @@ source = { local = "../../Wormhole/core-v1" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.whusdte]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/_vendor/coins/xBTC/Move.lock
+++ b/_vendor/coins/xBTC/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.xbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/access-management/Move.lock
+++ b/access-management/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/core/Move.lock
+++ b/kai/leverage/core/Move.lock
@@ -159,3 +159,159 @@ source = { local = "../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/core/Move.lock
+++ b/kai/leverage/supply-pool-init/core/Move.lock
@@ -165,3 +165,165 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/deep/Move.lock
+++ b/kai/leverage/supply-pool-init/deep/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_deep]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "8836A461CDAFA05B24882E26AE3C3287FF38025BD1A15D7BB536A866581A0B3E"
+deps = { deep = "deep", kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/lbtc/Move.lock
+++ b/kai/leverage/supply-pool-init/lbtc/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_lbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "82D823DDBE56103AE8EAA194D3724FBDEBB5BC47CFB2B8AD4E0CD790E253579F"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", lbtc = "lbtc", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/paused-suiusdt/Move.lock
+++ b/kai/leverage/supply-pool-init/paused-suiusdt/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.paused_klsp_suiusdt]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "38F63535B5CE919B7490FA2CFC2D6829342682D13E2EB5E5F8FA0624F9C6E074"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/paused-usdc/Move.lock
+++ b/kai/leverage/supply-pool-init/paused-usdc/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.paused_klsp_usdc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "C9FF514214511B584F59AFC77457F0CAD3DE3B929DD0D1EE5A379C28ECCB46B1"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", usdc = "usdc" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/sui/Move.lock
+++ b/kai/leverage/supply-pool-init/sui/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_sui]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "E9FEDD719F0AAA3D82AD9DA175C0B347345D5B4B3B8630706823B06F34C9F0C8"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/suiusdt/Move.lock
+++ b/kai/leverage/supply-pool-init/suiusdt/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_suiusdt]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "38F63535B5CE919B7490FA2CFC2D6829342682D13E2EB5E5F8FA0624F9C6E074"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/usdc/Move.lock
+++ b/kai/leverage/supply-pool-init/usdc/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_usdc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "C9FF514214511B584F59AFC77457F0CAD3DE3B929DD0D1EE5A379C28ECCB46B1"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", usdc = "usdc" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/usdy/Move.lock
+++ b/kai/leverage/supply-pool-init/usdy/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_usdy]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "34F10C11A05CD05F91A2F29D3EE68E3EB7F41C0B48287DAB978526FA51E27BAF"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", usdy = "usdy" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/wal/Move.lock
+++ b/kai/leverage/supply-pool-init/wal/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_wal]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "3A7F5F39EF4E0AB2444767D068610EDB9F158A8CFE15E551552E02AD5646991B"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", wal = "wal" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/wbtc/Move.lock
+++ b/kai/leverage/supply-pool-init/wbtc/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_wbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5EE21686F498C48BE810BE4ACFB2A62A3FAB24C0951F8B150127FB70DE9461E9"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", wbtc = "wbtc" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/whusdce/Move.lock
+++ b/kai/leverage/supply-pool-init/whusdce/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_whusdce]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "84F6689193AF2C59ADF70554BFE4482DCEDB0D6035F9B077DD3A030DCB38C3A9"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", whusdce = "whusdce" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/whusdte/Move.lock
+++ b/kai/leverage/supply-pool-init/whusdte/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_whusdte]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "3B219BC2A59281ACAD090FA4E7F592E4B87C04131EFF5D364C2EEC7452BE8F6D"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", whusdte = "whusdte" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/leverage/supply-pool-init/xbtc/Move.lock
+++ b/kai/leverage/supply-pool-init/xbtc/Move.lock
@@ -171,3 +171,171 @@ source = { local = "../../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.klsp_init]
+source = { local = "../core" }
+use_environment = "testnet"
+manifest_digest = "DAE240FD9BE724BB7C625EFEE993DD04CB092E267C5E81020C5634D21EFB039E"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.klsp_xbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "40F1A3CEEEA34E647214F6AFB8DFF34ED979D0AF35C1F431342F956849FF02CC"
+deps = { kai_leverage = "kai_leverage", klsp_init = "klsp_init", std = "MoveStdlib", sui = "Sui", xbtc = "xbtc" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/core/Move.lock
+++ b/kai/sav/core/Move.lock
@@ -213,3 +213,213 @@ source = { local = "../../../_vendor/coins/xBTC" }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.access_management]
+source = { local = "../../../access-management" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.bluefin_spot]
+source = { local = "../../../_vendor/Bluefin/spot-v17" }
+use_environment = "testnet"
+manifest_digest = "D9F8D7EF4D6A1EFBDE2F84F7F9CE524193D8E2CAB250D0AE01451881FEABDDAF"
+deps = { integer_library = "integer_library", integer_mate = "integer_mate", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.cetus_clmm]
+source = { local = "../../../_vendor/Cetus/clmm-v13" }
+use_environment = "testnet"
+manifest_digest = "AA1E11CF782D4544DCB978407AF89B5DF9851B2ECF80E93B2D30FBA628682A8C"
+deps = { integer_mate = "integer_mate_1", move_stl = "move_stl", std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.coin_decimals_registry]
+source = { local = "../../../_vendor/Scallop/coin-decimals-registry-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.deep]
+source = { local = "../../../_vendor/coins/DEEP" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_library]
+source = { local = "../../../_vendor/Bluefin/integer-library-v3" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate]
+source = { local = "../../../_vendor/Cetus/integer-mate-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.integer_mate_1]
+source = { local = "../../../_vendor/Cetus/integer-mate-v7" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.kai_leverage]
+source = { local = "../../leverage/core" }
+use_environment = "testnet"
+manifest_digest = "6C10676793518B7C45ECF7E94BD1E5D4AA93573FA98B441BB266CDA189137361"
+deps = { access_management = "access_management", bluefin_spot = "bluefin_spot", cetus_clmm = "cetus_clmm", deep = "deep", integer_mate = "integer_mate_1", lbtc = "lbtc", pyth = "pyth", rate_limiter = "rate_limiter", std = "MoveStdlib", sui = "Sui", suiusdt = "suiusdt", usdc = "usdc", usdy = "usdy", wal = "wal", wbtc = "wbtc", whusdce = "whusdce", whusdte = "whusdte", xbtc = "xbtc" }
+
+[pinned.testnet.kai_sav]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "676A291429E4ED97D3C02BE734982F0070C052582819912533F7CDDDEEB8D828"
+deps = { access_management = "access_management", kai_leverage = "kai_leverage", kai_ywhusdte_ysui = "kai_ywhusdte_ysui", rate_limiter = "rate_limiter", scallop_pool = "spool", scallop_protocol = "protocol", std = "MoveStdlib", sui = "Sui", whusdce = "whusdce", whusdte = "whusdte" }
+
+[pinned.testnet.kai_ywhusdte_ysui]
+source = { local = "../vault-token-init/kai-ywhusdte-ysui" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.lbtc]
+source = { local = "../../../_vendor/coins/LBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.math]
+source = { local = "../../../_vendor/Scallop/math-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.move_stl]
+source = { local = "../../../_vendor/Cetus/move-stl-v5" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.protocol]
+source = { local = "../../../_vendor/Scallop/protocol-v10" }
+use_environment = "testnet"
+manifest_digest = "3D851B35976E357336D49227D57B4E39D10197D63AD13BEA3EE180A3C85C69E6"
+deps = { coin_decimals_registry = "coin_decimals_registry", math = "math", std = "MoveStdlib", sui = "Sui", whitelist = "whitelist", x = "x", x_oracle = "x_oracle" }
+
+[pinned.testnet.pyth]
+source = { local = "../../../_vendor/Pyth/core-v2" }
+use_environment = "testnet"
+manifest_digest = "60D9BA538AAD24D3181112C5BBA76EE2BBA122176633C60B7546736160F60B66"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.rate_limiter]
+source = { local = "../../../rate-limiter" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.spool]
+source = { local = "../../../_vendor/Scallop/spool-v2" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.stablecoin]
+source = { local = "../../../_vendor/Circle/stablecoin-v1" }
+use_environment = "testnet"
+manifest_digest = "8162B212B46576BC32CDC268DD3E7865CD57E7B4348A2227923486C94D5DE5BB"
+deps = { std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.sui_extensions]
+source = { local = "../../../_vendor/Circle/sui-extensions-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.suiusdt]
+source = { local = "../../../_vendor/coins/suiUSDT" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.token_bridge]
+source = { local = "../../../_vendor/Wormhole/token-bridge-v1" }
+use_environment = "testnet"
+manifest_digest = "AA2D39CB1A57092AEC7CB2C08E4C7F53826DF1DE967BF797D0277B173D620792"
+deps = { std = "MoveStdlib", sui = "Sui", wormhole = "wormhole" }
+
+[pinned.testnet.usdc]
+source = { local = "../../../_vendor/coins/USDC" }
+use_environment = "testnet"
+manifest_digest = "1243713A9D84C599FCC221784E9F0F06A20FCDA8796FEB1751383472100CA69A"
+deps = { stablecoin = "stablecoin", std = "MoveStdlib", sui = "Sui", sui_extensions = "sui_extensions" }
+
+[pinned.testnet.usdy]
+source = { local = "../../../_vendor/coins/USDY" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wal]
+source = { local = "../../../_vendor/coins/WAL" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.wbtc]
+source = { local = "../../../_vendor/coins/wBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whitelist]
+source = { local = "../../../_vendor/Scallop/whitelist-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.whusdce]
+source = { local = "../../../_vendor/coins/whUSDCe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.whusdte]
+source = { local = "../../../_vendor/coins/whUSDTe" }
+use_environment = "testnet"
+manifest_digest = "77E20FC3960FA97B96D2B8D204F82C6B7E329F4446AA640015D58820D5397652"
+deps = { std = "MoveStdlib", sui = "Sui", token_bridge = "token_bridge" }
+
+[pinned.testnet.wormhole]
+source = { local = "../../../_vendor/Wormhole/core-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.x]
+source = { local = "../../../_vendor/Scallop/x-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.x_oracle]
+source = { local = "../../../_vendor/Scallop/x-oracle-v1" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.xbtc]
+source = { local = "../../../_vendor/coins/xBTC" }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-ydeep/Move.lock
+++ b/kai/sav/vault-token-init/kai-ydeep/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_ydeep]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-ylbtc/Move.lock
+++ b/kai/sav/vault-token-init/kai-ylbtc/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_ylbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-ysuiusdt/Move.lock
+++ b/kai/sav/vault-token-init/kai-ysuiusdt/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_ysuiusdt]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-yusdc/Move.lock
+++ b/kai/sav/vault-token-init/kai-yusdc/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_yusdc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-yusdy/Move.lock
+++ b/kai/sav/vault-token-init/kai-yusdy/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_yusdy]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-ywal/Move.lock
+++ b/kai/sav/vault-token-init/kai-ywal/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_ywal]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-ywbtc/Move.lock
+++ b/kai/sav/vault-token-init/kai-ywbtc/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_ywbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-ywhusdte-ysui/Move.lock
+++ b/kai/sav/vault-token-init/kai-ywhusdte-ysui/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_ywhusdte_ysui]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/kai-yxbtc/Move.lock
+++ b/kai/sav/vault-token-init/kai-yxbtc/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.kai_yxbtc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/paused-kai-ysuiusdt/Move.lock
+++ b/kai/sav/vault-token-init/paused-kai-ysuiusdt/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.paused_kai_ysuiusdt]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/kai/sav/vault-token-init/paused-kai-yusdc/Move.lock
+++ b/kai/sav/vault-token-init/paused-kai-yusdc/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.paused_kai_yusdc]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }

--- a/rate-limiter/Move.lock
+++ b/rate-limiter/Move.lock
@@ -21,3 +21,21 @@ source = { root = true }
 use_environment = "mainnet"
 manifest_digest = "E41BBD67BE8940D26C79D78B028477EF5B33BA217A1282C78ACB344CF8A5ECF6"
 deps = { std = "MoveStdlib", sui = "Sui" }
+
+[pinned.testnet.MoveStdlib]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/move-stdlib", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "C4FE4C91DE74CBF223B2E380AE40F592177D21870DC2D7EB6227D2D694E05363"
+deps = {}
+
+[pinned.testnet.Sui]
+source = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework/packages/sui-framework", rev = "c2428b3aaf9c24270b609001e56d96cb10c76d28" }
+use_environment = "testnet"
+manifest_digest = "7AFB66695545775FBFBB2D3078ADFD084244D5002392E837FDE21D9EA1C6D01C"
+deps = { MoveStdlib = "MoveStdlib" }
+
+[pinned.testnet.rate_limiter]
+source = { root = true }
+use_environment = "testnet"
+manifest_digest = "5745706258F61D6CE210904B3E6AE87A73CE9D31A6F93BE4718C442529332A87"
+deps = { std = "MoveStdlib", sui = "Sui" }


### PR DESCRIPTION
## Summary

Adds `[pinned.testnet.*]` entries to all package and `_vendor` `Move.lock` files. Previously only mainnet was pinned, which forced `sui move test` to re-resolve testnet deps from git on every run (and contributed to the `PACKAGE_ARENA_LIMIT_REACHED` failures on the leverage-core test suite). With both envs pre-pinned, dep resolution is deterministic and offline.

Generated by running the lockfile regenerator over both `-e mainnet` and `-e testnet`. No source code changes.

## Test plan

- [x] All 59 `Move.lock` files updated; no source files touched
- [x] Spot-check that the new `[pinned.testnet.*]` blocks reference the same Sui framework rev as private's lockfiles