### PR TITLE
ci: add GitHub Actions for Move tests and lint

### DIFF
--- a/.github/actions/setup-sui/action.yml
+++ b/.github/actions/setup-sui/action.yml
@@ -1,0 +1,34 @@
+name: Setup Sui
+description: Install Sui CLI (cached) and prime the Move dep cache.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Sui CLI
+      id: cache-sui
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/bin/sui
+        key: sui-${{ runner.os }}-${{ env.SUI_VERSION }}
+
+    - name: Install Sui CLI
+      if: steps.cache-sui.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/MystenLabs/suiup/main/install.sh | sh
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        suiup install sui@${{ env.SUI_VERSION }} --yes
+
+    - name: Add Sui to PATH
+      shell: bash
+      run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Cache Move deps
+      uses: actions/cache@v4
+      with:
+        path: ~/.move
+        key: move-${{ runner.os }}-${{ env.SUI_VERSION }}-${{ hashFiles('**/Move.lock') }}
+        restore-keys: |
+          move-${{ runner.os }}-${{ env.SUI_VERSION }}-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Bump deliberately. Verify locally with `./scripts/test.sh` before bumping.
+  # `mainnet-X.Y.Z` and `testnet-X.Y.Z` are different builds even at the same
+  # version number. Match the channel the team develops/tests against.
+  SUI_VERSION: mainnet-1.70.2
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-sui
+      - run: ./scripts/test.sh
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-sui
+      - run: ./scripts/lint.sh

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Run the Move linter for every top-level Move package in this repo.
+#
+# Uses `sui move test --warnings-are-errors -- __no_match_lint_only__`:
+#   - `sui move test` is the only command that compiles in test mode (so the
+#     linter sees test files and #[mode(test)] items). `sui move build` only
+#     compiles non-test sources, missing those lints. `sui move build --test`
+#     is rejected by the CLI.
+#   - `--warnings-are-errors` promotes lint warnings to errors so the script
+#     fails on lint findings.
+#   - The trailing `__no_match_lint_only__` is a test-name filter that matches
+#     no tests, so the linter runs but no tests execute.
+#
+# Skips _vendor/ (external snapshots) and build/ artifact dirs. Continues
+# through failures so every package is exercised; exits non-zero at the end
+# if any package failed.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+mapfile -t PACKAGES < <(
+  find . -name Move.toml \
+    -not -path './_vendor/*' \
+    -not -path '*/build/*' \
+    -printf '%h\n' | sort
+)
+
+FAILED=()
+for pkg in "${PACKAGES[@]}"; do
+  echo "::group::$pkg"
+  if ! (cd "$pkg" && sui move test --build-env mainnet --warnings-are-errors -- __no_match_lint_only__); then
+    FAILED+=("$pkg")
+  fi
+  echo "::endgroup::"
+done
+
+echo
+if (( ${#FAILED[@]} > 0 )); then
+  echo "LINT FAILED (${#FAILED[@]}/${#PACKAGES[@]}):"
+  for pkg in "${FAILED[@]}"; do
+    echo "  $pkg"
+  done
+  exit 1
+fi
+echo "All packages clean (${#PACKAGES[@]} total)."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Run `sui move test` for every top-level Move package in this repo.
+# Skips _vendor/ (external snapshots) and build/ artifact dirs.
+# Continues through failures so every package is exercised; exits non-zero
+# at the end if any package failed.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.."
+
+mapfile -t PACKAGES < <(
+  find . -name Move.toml \
+    -not -path './_vendor/*' \
+    -not -path '*/build/*' \
+    -printf '%h\n' | sort
+)
+
+FAILED=()
+for pkg in "${PACKAGES[@]}"; do
+  echo "::group::$pkg"
+  if ! (cd "$pkg" && sui move test --build-env mainnet); then
+    FAILED+=("$pkg")
+  fi
+  echo "::endgroup::"
+done
+
+echo
+if (( ${#FAILED[@]} > 0 )); then
+  echo "FAILED (${#FAILED[@]}/${#PACKAGES[@]}):"
+  for pkg in "${FAILED[@]}"; do
+    echo "  $pkg"
+  done
+  exit 1
+fi
+echo "All packages passed (${#PACKAGES[@]} total)."


### PR DESCRIPTION
Adds a two-job CI workflow that runs on PRs to master and pushes to master.

## Jobs

- **`test`** (blocking): runs `sui move test --build-env mainnet` for every non-vendored Move package via `scripts/test.sh`. Dynamic discovery via `find`, so new packages are picked up automatically.
- **`lint`** (non-blocking): runs `sui move test --build-env mainnet --warnings-are-errors -- __no_match_lint_only__` per package via `scripts/lint.sh`. The no-match filter compiles in test mode (so the linter sees test files), runs the linter pass, then matches zero tests to skip execution.

`--build-env mainnet` is required: with v4 lockfiles having both `[pinned.mainnet.*]` and `[pinned.testnet.*]` sections (whose framework manifest digests differ even at the same git rev), the active env in the sui client config determines which block is used. Without the flag, CI's auto-created sui config defaults to testnet, which compiles against a different framework than what's tested locally. The flag makes the build deterministic.

Both jobs use a shared composite action at `.github/actions/setup-sui` that installs the Sui CLI via [`suiup`](https://github.com/MystenLabs/suiup) (pinned to `mainnet-1.70.2`) and caches `~/.move` deps keyed on `Move.lock` hashes.

## Branch protection setup (manual, one-time)

For `lint` to be non-blocking, configure on master:

> Settings → Branches → master → Require status checks to pass before merging → required checks: **`test` only**

Without that, both checks gate merging equally.

## Local verification

Both scripts run end-to-end locally with `sui 1.70.2` (testnet binary, active env switched to testnet to mirror CI):

- `./scripts/test.sh` → all 31 packages pass.
- `./scripts/lint.sh` → 13/31 fail with real pre-existing lint findings (deprecated `vec_set::size`, invalid doc comments in `kai/sav/core/sources/farm/farm.move`, plus 12 `vault-token-init/*` packages propagating from `kai/sav/core`). These are tracked separately and don't block this PR landing.